### PR TITLE
ALP-1639/ALP-1660: Fix flaky + fake-timer-broken gateway conductor tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,25 @@ AUTHORCLAW_VAULT_KEY=
 # OPTIONAL: Path to Author OS tools (if installed separately)
 # AUTHOR_OS_PATH=/path/to/author-os
 
-# OPTIONAL: Where live project data (book bible, chapters, memory, audit
-# logs, costs, etc.) is stored. Defaults to ./workspace inside this install.
-# Point this elsewhere — e.g. a separate git-tracked repo — to keep your
-# manuscript's version history independent of AuthorAgent's own.
+# OPTIONAL: Root directory that holds your book workspace(s) — book bible,
+# chapters, memory, audit logs, costs, etc. Defaults to ./workspace inside
+# this install. Point this elsewhere — e.g. a separate git-tracked repo — to
+# keep your manuscript's version history independent of AuthorAgent's own.
+#
+# One AuthorAgent instance runs ONE active book at a time. If this root
+# already looks like a flat single-book workspace (has memory/, soul/, or
+# projects/ directly inside it) and no active book is selected below, it is
+# used as-is — existing single-book installs need no changes here.
+#
+# To run more than one book, use `npm run book -- create <name>` to scaffold
+# each one under this root as <root>/<book-slug>/, then either set
+# AUTHORCLAW_ACTIVE_BOOK below or run `npm run book -- use <slug>` (writes a
+# <root>/.active-book pointer file — env wins if both are set). Switching only
+# takes effect on restart. See `npm run book -- list` and LAUNCH-GUIDE.md.
+#
+# For a SECOND book running at the same time as the first, skip all of this
+# and just start a second AuthorAgent process pointed at a different
+# AUTHORCLAW_WORKSPACE_DIR (and a different server.port in config/user.json).
 # AUTHORCLAW_WORKSPACE_DIR=/path/to/your-project-repo/authoragent-workspace
+# AUTHORCLAW_PROJECTS_ROOT=  # alias for AUTHORCLAW_WORKSPACE_DIR, same meaning
+# AUTHORCLAW_ACTIVE_BOOK=    # book slug to boot; overrides the .active-book pointer file

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,9 @@ AUTHORCLAW_VAULT_KEY=
 
 # OPTIONAL: Path to Author OS tools (if installed separately)
 # AUTHOR_OS_PATH=/path/to/author-os
+
+# OPTIONAL: Where live project data (book bible, chapters, memory, audit
+# logs, costs, etc.) is stored. Defaults to ./workspace inside this install.
+# Point this elsewhere — e.g. a separate git-tracked repo — to keep your
+# manuscript's version history independent of AuthorAgent's own.
+# AUTHORCLAW_WORKSPACE_DIR=/path/to/your-project-repo/authoragent-workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    name: check (tsc + vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run check

--- a/LAUNCH-GUIDE.md
+++ b/LAUNCH-GUIDE.md
@@ -95,6 +95,41 @@ Or set up a reverse proxy (Nginx/Caddy) with HTTPS + auth for public access.
 | Memory/Bible | `workspace/memory/` |
 | Self-improvement | `workspace/.agent/` |
 
+## Multiple Books
+
+One running AuthorAgent instance serves ONE **active book** at a time — all of
+a book's state (memory, soul, book bible, personas, images, costs, etc.) is
+per-book. `AUTHORCLAW_WORKSPACE_DIR` (see `.env.example`) is a ROOT that can
+hold many isolated per-book workspaces at `<root>/<book-slug>/`.
+
+**Existing single-book installs need no changes.** If the root already looks
+like a flat single-book workspace (has `memory/`, `soul/`, or `projects/`
+directly inside it) and no active book is selected, it's used in place exactly
+as before.
+
+To add a second book to the same root:
+
+```bash
+npm run book -- list                    # show books under the root + which is active
+npm run book -- create "My Second Book" # scaffold <root>/my-second-book/
+npm run book -- use my-second-book      # writes <root>/.active-book
+# restart the gateway — switching is restart-scoped, services are boot-time singletons
+```
+
+`AUTHORCLAW_ACTIVE_BOOK` in `.env` overrides the `.active-book` pointer file if
+you'd rather pin it there. Migrating an existing flat install into the
+multi-book layout on purpose (e.g. to give it a proper slug alongside new
+books) is one command and moves data, it doesn't copy/delete it:
+
+```bash
+npm run book -- migrate-legacy the-algorithm-of-wanting
+```
+
+**Need two books running at the same time, right now, with zero code
+changes?** Skip all of the above and start a second AuthorAgent process with
+its own `AUTHORCLAW_WORKSPACE_DIR` and its own `server.port`
+(`config/user.json`) — fully isolated, two processes instead of one.
+
 ## API Keys (Dashboard > Settings)
 
 All keys are stored in the encrypted vault. Set them via the dashboard:

--- a/config/default.json
+++ b/config/default.json
@@ -37,8 +37,14 @@
       "enabled": false,
       "model": "sonnet",
       "maxConcurrent": 2,
-      "inactivityTimeoutMs": 90000,
-      "maxTimeoutMs": 900000
+      "inactivityTimeoutMs": 60000,
+      "maxTimeoutMs": 900000,
+      "firstTokenTimeoutMs": 120000,
+      "firstTokenCeilingMs": 420000,
+      "queueWaitTimeoutMs": 600000,
+      "minSpawnGapMs": 1500,
+      "maxBackoffMs": 120000,
+      "canary": true
     }
   },
   "memory": {

--- a/config/default.json
+++ b/config/default.json
@@ -37,7 +37,8 @@
       "enabled": false,
       "model": "sonnet",
       "maxConcurrent": 2,
-      "timeoutMs": 300000
+      "inactivityTimeoutMs": 90000,
+      "maxTimeoutMs": 900000
     }
   },
   "memory": {

--- a/config/default.json
+++ b/config/default.json
@@ -9,6 +9,7 @@
   },
   "ai": {
     "preferredProvider": null,
+    "preferredProviderFallback": null,
     "preferredImageProvider": null,
     "maxHistoryMessages": 20,
     "defaultTemperature": 0.7,
@@ -31,6 +32,12 @@
     },
     "openrouter": {
       "model": "anthropic/claude-sonnet-4-5"
+    },
+    "claude-cli": {
+      "enabled": false,
+      "model": "sonnet",
+      "maxConcurrent": 2,
+      "timeoutMs": 300000
     }
   },
   "memory": {

--- a/dashboard/dist/index.html
+++ b/dashboard/dist/index.html
@@ -33,6 +33,12 @@
   --warn: #f59e0b;
   --sidebar-w: 240px;
   --sidebar-collapsed: 64px;
+  /* Default width for the chat drawer — was a fixed 380px, cramped for the
+     long-form responses this app routinely generates (full chapters,
+     multi-thousand-word outlines). Now a CSS var so the drag handle (see
+     chatDrawerResizeHandle below) can override it live; the value here is
+     just the first-run default before any user preference is saved. */
+  --chat-drawer-w: 760px;
   --radius: 12px;
   --radius-sm: 8px;
   --shadow: 0 1px 3px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.2);
@@ -392,7 +398,7 @@ textarea { resize: vertical; min-height: 60px; }
   position: fixed;
   top: 0;
   right: 0;
-  width: 380px;
+  width: var(--chat-drawer-w);
   max-width: 92vw;
   height: 100vh;
   background: var(--bg-secondary);
@@ -404,7 +410,25 @@ textarea { resize: vertical; min-height: 60px; }
   transition: transform 0.25s ease;
   z-index: 500;
 }
+/* No transition on width while actively dragging — otherwise every mousemove
+   fights a 0.25s easing and the drawer visibly lags behind the cursor. */
+.chat-drawer.resizing { transition: none; }
 .chat-drawer.open { transform: translateX(0); }
+.chat-drawer-resize-handle {
+  position: absolute;
+  top: 0;
+  left: -4px;
+  width: 8px;
+  height: 100%;
+  cursor: ew-resize;
+  z-index: 501;
+  background: transparent;
+}
+.chat-drawer-resize-handle:hover,
+.chat-drawer-resize-handle.dragging {
+  background: var(--accent);
+  opacity: 0.4;
+}
 .chat-drawer-header {
   display: flex;
   align-items: center;
@@ -1657,6 +1681,7 @@ textarea { resize: vertical; min-height: 60px; }
      ═══════════════════════════════════════════════ -->
 <div class="chat-drawer-overlay" id="chatDrawerOverlay"></div>
 <div class="chat-drawer" id="chatDrawer">
+  <div class="chat-drawer-resize-handle" id="chatDrawerResizeHandle" title="Drag to resize"></div>
   <div class="chat-drawer-header">
     <span class="card-title">Chat with AuthorAgent</span>
     <div style="display:flex;align-items:center;gap:8px;">
@@ -2154,6 +2179,80 @@ document.addEventListener('keydown', function(e) {
 });
 // Restore persisted state on load (default closed if never set).
 applyChatDrawerState(isChatDrawerOpen());
+
+// ── Chat Drawer Resize ──
+// Drag the left edge to resize; width persists across sessions. Was a fixed
+// 380px, cramped for the long-form output this app routinely generates
+// (full chapters, multi-thousand-word outlines) — see --chat-drawer-w above.
+var CHAT_DRAWER_WIDTH_KEY = 'authorclaw_chat_drawer_width';
+var CHAT_DRAWER_MIN_WIDTH = 340;
+function getChatDrawerMaxWidth() {
+  // Leave a little breathing room so the drawer can never fully swallow
+  // the main content area on a narrower laptop screen.
+  return Math.min(1400, window.innerWidth - 200);
+}
+function clampChatDrawerWidth(px) {
+  return Math.max(CHAT_DRAWER_MIN_WIDTH, Math.min(getChatDrawerMaxWidth(), px));
+}
+function applyChatDrawerWidth(px) {
+  document.documentElement.style.setProperty('--chat-drawer-w', px + 'px');
+}
+function restoreChatDrawerWidth() {
+  var saved;
+  try { saved = parseInt(localStorage.getItem(CHAT_DRAWER_WIDTH_KEY), 10); } catch (e) { saved = NaN; }
+  if (!isNaN(saved) && saved > 0) applyChatDrawerWidth(clampChatDrawerWidth(saved));
+}
+(function setupChatDrawerResize() {
+  var handle = document.getElementById('chatDrawerResizeHandle');
+  var drawer = document.getElementById('chatDrawer');
+  if (!handle || !drawer) return;
+
+  var dragging = false;
+
+  function onMove(e) {
+    if (!dragging) return;
+    var clientX = e.touches ? e.touches[0].clientX : e.clientX;
+    // Drawer is right-anchored (right: 0), so its width is just the
+    // distance from the cursor to the viewport's right edge.
+    var width = clampChatDrawerWidth(window.innerWidth - clientX);
+    applyChatDrawerWidth(width);
+  }
+  function onEnd() {
+    if (!dragging) return;
+    dragging = false;
+    drawer.classList.remove('resizing');
+    handle.classList.remove('dragging');
+    document.body.style.userSelect = '';
+    var current = drawer.getBoundingClientRect().width;
+    try { localStorage.setItem(CHAT_DRAWER_WIDTH_KEY, String(Math.round(current))); } catch (e) { /* ignore */ }
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', onEnd);
+    document.removeEventListener('touchmove', onMove);
+    document.removeEventListener('touchend', onEnd);
+  }
+  function onStart(e) {
+    dragging = true;
+    drawer.classList.add('resizing');
+    handle.classList.add('dragging');
+    document.body.style.userSelect = 'none'; // prevent text selection while dragging
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onEnd);
+    document.addEventListener('touchmove', onMove, { passive: true });
+    document.addEventListener('touchend', onEnd);
+    e.preventDefault();
+  }
+  handle.addEventListener('mousedown', onStart);
+  handle.addEventListener('touchstart', onStart, { passive: false });
+
+  // Re-clamp on viewport resize so a saved wide-monitor width doesn't blow
+  // past the (window-dependent) max if the browser window shrinks later.
+  window.addEventListener('resize', function() {
+    var current = drawer.getBoundingClientRect().width;
+    var clamped = clampChatDrawerWidth(current);
+    if (clamped !== current) applyChatDrawerWidth(clamped);
+  });
+})();
+restoreChatDrawerWidth();
 
 // ================================================================
 // PROJECTS PANEL

--- a/dashboard/dist/index.html
+++ b/dashboard/dist/index.html
@@ -3280,6 +3280,13 @@ function openProjectDetail(id) {
         '<div style="font-size:12px;color:var(--muted);margin-bottom:8px;">Check this book\'s outline against a known dramatic structure.</div>' +
         '<button class="secondary" id="pdStructureRun" style="font-size:12px;padding:6px 14px;">Analyze Structure</button>' +
         '<div id="pdStructureResults" style="margin-top:12px;"></div>' +
+        '<div class="card-title" style="margin-top:20px;">Book Bible</div>' +
+        '<div style="font-size:12px;color:var(--muted);margin-bottom:8px;">One canonical, reviewable doc — characters, timeline, locations, world rules, and items — compiled from tracked story context.</div>' +
+        '<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:10px;">' +
+          '<button class="secondary" id="pdBibleCompile" style="font-size:12px;padding:6px 14px;">Compile Book Bible</button>' +
+          '<button class="secondary" id="pdBibleDownload" style="font-size:12px;padding:6px 14px;display:none;">Download .md</button>' +
+        '</div>' +
+        '<div id="pdBibleContent" style="font-size:12px;color:var(--muted);"></div>' +
       '</div>' +
       // ── WRITE (default) ──
       '<div class="card pd-tab-content" id="pdTabWrite">' +
@@ -3448,6 +3455,12 @@ function openProjectDetail(id) {
   var pdCompile = detail.querySelector('#pdCompile');
   if (pdCompile) pdCompile.addEventListener('click', function() { compileProject(id); });
 
+  // Wire Book Bible compile/download (in Plan stage)
+  var pdBibleCompile = detail.querySelector('#pdBibleCompile');
+  if (pdBibleCompile) pdBibleCompile.addEventListener('click', function() { compileProjectBible(id); });
+  var pdBibleDownload = detail.querySelector('#pdBibleDownload');
+  if (pdBibleDownload) pdBibleDownload.addEventListener('click', function() { downloadProjectBible(id); });
+
   // ── Stage tabs ──
   var loaded = { plan: false, polish: false };
   function activateStage(tabName) {
@@ -3460,7 +3473,7 @@ function openProjectDetail(id) {
     detail.querySelectorAll('.pd-tab-content').forEach(function(c) { c.style.display = 'none'; });
     var target = detail.querySelector('#pdTab' + tabName.charAt(0).toUpperCase() + tabName.slice(1));
     if (target) target.style.display = 'block';
-    if (tabName === 'plan' && !loaded.plan) { loaded.plan = true; loadProjectContext(id); }
+    if (tabName === 'plan' && !loaded.plan) { loaded.plan = true; loadProjectContext(id); loadProjectBible(id); }
     if (tabName === 'polish' && !loaded.polish) { loaded.polish = true; loadProjectFiles(id); }
   }
   detail.querySelectorAll('.pd-tab').forEach(function(tab) {
@@ -3703,6 +3716,62 @@ function compileProject(id) {
       showToast(data.error || 'Compile failed', 'error');
     }
   }).catch(function(e) { showToast('Compile failed: ' + e.message, 'error'); });
+}
+
+// ================================================================
+// BOOK BIBLE
+// ================================================================
+var bibleContentCache = {};
+
+function renderBibleContent(id, content) {
+  var el = document.getElementById('pdBibleContent');
+  var dl = document.getElementById('pdBibleDownload');
+  if (!el) return;
+  bibleContentCache[id] = content;
+  if (dl) dl.style.display = content ? 'inline-block' : 'none';
+  if (!content) {
+    el.innerHTML = '<span style="color:var(--muted);">Not compiled yet. Click "Compile Book Bible" to generate it from tracked story context.</span>';
+    return;
+  }
+  el.innerHTML = '<pre style="white-space:pre-wrap;font-size:12px;background:var(--bg);padding:12px;border-radius:6px;max-height:400px;overflow:auto;border:1px solid var(--border);">' + esc(content) + '</pre>';
+}
+
+function loadProjectBible(id) {
+  var el = document.getElementById('pdBibleContent');
+  if (el) el.innerHTML = '<span style="color:var(--muted);">Loading...</span>';
+  api('GET', '/api/projects/' + id + '/book-bible').then(function(data) {
+    renderBibleContent(id, data.content || '');
+  }).catch(function() {
+    // Not compiled yet (404) or a transient load failure — same empty state either way.
+    renderBibleContent(id, '');
+  });
+}
+
+function compileProjectBible(id) {
+  showToast('Compiling book bible...', 'info');
+  api('POST', '/api/projects/' + id + '/book-bible').then(function(data) {
+    if (data.success) {
+      var counts = data.counts || {};
+      showToast('Book bible compiled! ' + (counts.characters || 0) + ' characters, ' + (counts.locations || 0) + ' locations.', 'success');
+      renderBibleContent(id, data.content);
+    } else {
+      showToast(data.error || 'Book bible compile failed', 'error');
+    }
+  }).catch(function(e) { showToast('Book bible compile failed: ' + e.message, 'error'); });
+}
+
+function downloadProjectBible(id) {
+  var content = bibleContentCache[id];
+  if (!content) return;
+  var blob = new Blob([content], { type: 'text/markdown' });
+  var url = URL.createObjectURL(blob);
+  var a = document.createElement('a');
+  a.href = url;
+  a.download = 'book-bible.md';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
 }
 
 // ================================================================

--- a/gateway/src/ai/router.test.ts
+++ b/gateway/src/ai/router.test.ts
@@ -851,36 +851,41 @@ describe('runClaudeCliOnce (streaming behavior, fake spawn)', () => {
   });
 
   it('two concurrent calls get distinct temp files, both cleaned up', async () => {
-    const child1 = makeFakeChild();
-    const child2 = makeFakeChild();
-    const children = [child1, child2];
-    const fakeSpawn = vi.fn((_bin: string, _args: string[], _opts?: any) => children.shift());
-    const router = new AIRouter({ 'claude-cli': { enabled: false } }, vault, costs, undefined, { spawn: fakeSpawn as any });
+    vi.useFakeTimers();
+    try {
+      const child1 = makeFakeChild();
+      const child2 = makeFakeChild();
+      const children = [child1, child2];
+      const fakeSpawn = vi.fn((_bin: string, _args: string[], _opts?: any) => children.shift());
+      const router = new AIRouter({ 'claude-cli': { enabled: false } }, vault, costs, undefined, { spawn: fakeSpawn as any });
 
-    const p1 = (router as any).runClaudeCliOnce(
-      FAKE_PROVIDER, { provider: 'claude-cli', system: 'sys A', messages: [{ role: 'user', content: 'hi' }] }, Date.now()
-    );
-    const p2 = (router as any).runClaudeCliOnce(
-      FAKE_PROVIDER, { provider: 'claude-cli', system: 'sys B', messages: [{ role: 'user', content: 'hi' }] }, Date.now()
-    );
-    await vi.waitFor(() => expect(fakeSpawn).toHaveBeenCalledTimes(2));
+      const p1 = (router as any).runClaudeCliOnce(
+        FAKE_PROVIDER, { provider: 'claude-cli', system: 'sys A', messages: [{ role: 'user', content: 'hi' }] }, Date.now()
+      );
+      const p2 = (router as any).runClaudeCliOnce(
+        FAKE_PROVIDER, { provider: 'claude-cli', system: 'sys B', messages: [{ role: 'user', content: 'hi' }] }, Date.now()
+      );
+      await vi.waitFor(() => expect(fakeSpawn).toHaveBeenCalledTimes(2));
 
-    const args1: string[] = fakeSpawn.mock.calls[0][1];
-    const args2: string[] = fakeSpawn.mock.calls[1][1];
-    const file1 = args1[args1.indexOf('--system-prompt-file') + 1];
-    const file2 = args2[args2.indexOf('--system-prompt-file') + 1];
-    expect(file1).not.toBe(file2);
+      const args1: string[] = fakeSpawn.mock.calls[0][1];
+      const args2: string[] = fakeSpawn.mock.calls[1][1];
+      const file1 = args1[args1.indexOf('--system-prompt-file') + 1];
+      const file2 = args2[args2.indexOf('--system-prompt-file') + 1];
+      expect(file1).not.toBe(file2);
 
-    child1.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'A' }) + '\n'));
-    child2.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'B' }) + '\n'));
+      child1.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'A' }) + '\n'));
+      child2.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'B' }) + '\n'));
 
-    const [r1, r2] = await Promise.all([p1, p2]);
-    expect(r1.text).toBe('A');
-    expect(r2.text).toBe('B');
+      const [r1, r2] = await Promise.all([p1, p2]);
+      expect(r1.text).toBe('A');
+      expect(r2.text).toBe('B');
 
-    const { access } = await import('node:fs/promises');
-    await expect(access(file1)).rejects.toThrow();
-    await expect(access(file2)).rejects.toThrow();
+      const { access } = await import('node:fs/promises');
+      await expect(access(file1)).rejects.toThrow();
+      await expect(access(file2)).rejects.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/gateway/src/ai/router.test.ts
+++ b/gateway/src/ai/router.test.ts
@@ -877,7 +877,7 @@ describe('runClaudeCliOnce (streaming behavior, fake spawn)', () => {
     );
     await vi.waitFor(() => expect(fakeSpawn).toHaveBeenCalledTimes(2));
 
-    const files = fakeSpawn.mock.calls.map(([, args]: [string, string[]]) => args[args.indexOf('--system-prompt-file') + 1]);
+    const files = fakeSpawn.mock.calls.map(([, args]) => args[args.indexOf('--system-prompt-file') + 1]);
     const [file1, file2] = files;
     expect(file1).not.toBe(file2);
 

--- a/gateway/src/ai/router.test.ts
+++ b/gateway/src/ai/router.test.ts
@@ -2,7 +2,22 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { AIRouter, getRecommendedThinking, getOutputBudget } from './router.js';
+import { EventEmitter } from 'node:events';
+import {
+  AIRouter,
+  getRecommendedThinking,
+  getOutputBudget,
+  buildClaudeCliArgs,
+  buildClaudeCliEnv,
+  classifyClaudeCliFailure,
+  parseClaudeCliResultEvent,
+  createNdjsonLineReader,
+  computeFirstTokenBudgetMs,
+  deriveLengthDirective,
+  mapThinkingToMaxThinkingTokens,
+  isSafeClaudeCliModel,
+  ClaudeCliError,
+} from './router.js';
 import { Vault } from '../security/vault.js';
 import { CostTracker } from '../services/costs.js';
 
@@ -411,5 +426,532 @@ describe('AIRouter provider selection and tiering (mocked vault/network)', () =>
       expect(stats2.hits).toBe(1);
       expect(stats2.savedTokens).toBeGreaterThan(0);
     });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// claude-cli hardening — pure functions
+// ═══════════════════════════════════════════════════════════
+//
+// This provider had ZERO test coverage despite being the live default in
+// production, and the specific failure that motivated this rewrite
+// (stream-json not actually streaming without --include-partial-messages,
+// making the "inactivity" watchdog a total-duration timeout in disguise)
+// shipped without any test catching it. These cover the extracted pure
+// logic directly; the streaming/timeout state machine itself is covered
+// further below via dependency-injected spawn.
+
+describe('buildClaudeCliArgs', () => {
+  it('builds the exact hardened, non-agentic argv', () => {
+    const args = buildClaudeCliArgs({ model: 'sonnet', systemPromptFile: '/tmp/sp.txt' });
+    expect(args).toEqual([
+      '-p',
+      '--output-format', 'stream-json',
+      '--verbose',
+      '--include-partial-messages',
+      '--model', 'sonnet',
+      '--system-prompt-file', '/tmp/sp.txt',
+      '--tools', '',
+      '--disable-slash-commands',
+      '--strict-mcp-config',
+      '--setting-sources', '',
+      '--no-session-persistence',
+      '--max-turns', '1',
+    ]);
+  });
+
+  it('never includes --bare or --dangerously-skip-permissions (would break OAuth / silently widen tool access)', () => {
+    const args = buildClaudeCliArgs({ model: 'opus', systemPromptFile: '/tmp/sp.txt', maxTurns: 12 });
+    expect(args).not.toContain('--bare');
+    expect(args).not.toContain('--dangerously-skip-permissions');
+    expect(args).not.toContain('--system-prompt'); // the (different) non-file flag
+  });
+
+  it('--tools is never the last argv element (it is variadic and would swallow whatever follows)', () => {
+    const args = buildClaudeCliArgs({ model: 'sonnet', systemPromptFile: '/tmp/sp.txt' });
+    const toolsIdx = args.indexOf('--tools');
+    expect(toolsIdx).toBeGreaterThanOrEqual(0);
+    expect(toolsIdx).toBeLessThan(args.length - 2); // '' plus at least one more flag after it
+  });
+
+  it('includes --max-thinking-tokens only when a thinking budget is given', () => {
+    const withThinking = buildClaudeCliArgs({ model: 'sonnet', systemPromptFile: '/tmp/sp.txt', maxThinkingTokens: 4096 });
+    expect(withThinking).toContain('--max-thinking-tokens');
+    expect(withThinking[withThinking.indexOf('--max-thinking-tokens') + 1]).toBe('4096');
+
+    const without = buildClaudeCliArgs({ model: 'sonnet', systemPromptFile: '/tmp/sp.txt' });
+    expect(without).not.toContain('--max-thinking-tokens');
+  });
+
+  it('respects a custom maxTurns', () => {
+    const args = buildClaudeCliArgs({ model: 'sonnet', systemPromptFile: '/tmp/sp.txt', maxTurns: 3 });
+    expect(args[args.indexOf('--max-turns') + 1]).toBe('3');
+  });
+});
+
+describe('buildClaudeCliEnv', () => {
+  it('strips credential-shaped vars so the child can never silently switch to metered API billing', () => {
+    const env = buildClaudeCliEnv({
+      ANTHROPIC_API_KEY: 'sk-should-not-leak',
+      ANTHROPIC_BASE_URL: 'https://evil.example.com',
+      GEMINI_API_KEY: 'g-key',
+      OPENAI_API_KEY: 'o-key',
+      AUTHORCLAW_VAULT_KEY: 'vault-secret',
+      CLAUDE_CODE_USE_BEDROCK: '1',
+      PATH: 'C:\\Windows\\System32',
+    });
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(env.GEMINI_API_KEY).toBeUndefined();
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.AUTHORCLAW_VAULT_KEY).toBeUndefined();
+    expect(env.CLAUDE_CODE_USE_BEDROCK).toBeUndefined();
+  });
+
+  it('keeps the vars OAuth/process startup depends on (regression guard: never break login)', () => {
+    const env = buildClaudeCliEnv({
+      USERPROFILE: 'C:\\Users\\test',
+      HOME: '/home/test',
+      APPDATA: 'C:\\Users\\test\\AppData\\Roaming',
+      LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local',
+      PATH: 'C:\\Windows\\System32',
+      TEMP: 'C:\\Temp',
+    });
+    expect(env.USERPROFILE).toBe('C:\\Users\\test');
+    expect(env.HOME).toBe('/home/test');
+    expect(env.APPDATA).toBe('C:\\Users\\test\\AppData\\Roaming');
+    expect(env.LOCALAPPDATA).toBe('C:\\Users\\test\\AppData\\Local');
+    expect(env.PATH).toBe('C:\\Windows\\System32');
+    expect(env.TEMP).toBe('C:\\Temp');
+  });
+
+  it('omits anything not on the explicit allowlist, even if harmless-looking', () => {
+    const env = buildClaudeCliEnv({ RANDOM_UNRELATED_VAR: 'x', PATH: 'y' });
+    expect(env.RANDOM_UNRELATED_VAR).toBeUndefined();
+    expect(env.PATH).toBe('y');
+  });
+});
+
+describe('isSafeClaudeCliModel', () => {
+  it('accepts normal model slugs/aliases', () => {
+    expect(isSafeClaudeCliModel('sonnet')).toBe(true);
+    expect(isSafeClaudeCliModel('claude-sonnet-4-5-20250929')).toBe(true);
+    expect(isSafeClaudeCliModel('opus')).toBe(true);
+  });
+
+  it('rejects a model value containing shell/argv-hostile characters', () => {
+    expect(isSafeClaudeCliModel('sonnet && calc')).toBe(false);
+    expect(isSafeClaudeCliModel('sonnet; rm -rf /')).toBe(false);
+    expect(isSafeClaudeCliModel('sonnet\n--dangerously-skip-permissions')).toBe(false);
+    expect(isSafeClaudeCliModel('')).toBe(false);
+  });
+});
+
+describe('classifyClaudeCliFailure', () => {
+  it('classifies auth failures and always returns the logout/login remedy', () => {
+    const r = classifyClaudeCliFailure({ resultText: 'API Error: 401 OAuth access token has expired.' });
+    expect(r.kind).toBe('auth');
+    expect(r.message).toContain('claude logout && claude login');
+  });
+
+  it('classifies quota/rate-limit failures and parses a reset deadline when present', () => {
+    const future = new Date(Date.now() + 3600_000).toISOString();
+    const r = classifyClaudeCliFailure({ resultText: `Usage limit reached. Resets at ${future}.` });
+    expect(r.kind).toBe('quota');
+    expect(r.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it('defaults quota retryAfterMs to 15 minutes when no deadline is parseable', () => {
+    const r = classifyClaudeCliFailure({ stderr: 'rate limit exceeded' });
+    expect(r.kind).toBe('quota');
+    expect(r.retryAfterMs).toBe(15 * 60_000);
+  });
+
+  it('classifies error_max_turns as fatal (should be impossible with --tools "" — a red flag if it recurs)', () => {
+    const r = classifyClaudeCliFailure({ resultText: 'error_max_turns' });
+    expect(r.kind).toBe('fatal');
+  });
+
+  it('falls back to transient for anything unrecognized', () => {
+    const r = classifyClaudeCliFailure({ resultText: 'some unexpected network blip' });
+    expect(r.kind).toBe('transient');
+  });
+
+  it('checks both resultText and stderr, not just one', () => {
+    const r = classifyClaudeCliFailure({ resultText: 'Command failed', stderr: 'not logged in' });
+    expect(r.kind).toBe('auth');
+  });
+});
+
+describe('parseClaudeCliResultEvent', () => {
+  it('parses a successful result event', () => {
+    const r = parseClaudeCliResultEvent({ type: 'result', is_error: false, result: 'hello', usage: { input_tokens: 10, output_tokens: 5 } });
+    expect(r).toEqual({ ok: true, text: 'hello', tokensUsed: 15 });
+  });
+
+  it('falls back to subtype when is_error is true and result text is empty', () => {
+    const r = parseClaudeCliResultEvent({ type: 'result', is_error: true, result: '', subtype: 'error_max_turns' });
+    expect(r).toEqual({ ok: false, error: 'error_max_turns' });
+  });
+
+  it('treats an empty, non-error result as a failure (never silently resolve with nothing)', () => {
+    const r = parseClaudeCliResultEvent({ type: 'result', is_error: false, result: '' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('defaults tokensUsed to 0 when usage is missing entirely', () => {
+    const r = parseClaudeCliResultEvent({ type: 'result', is_error: false, result: 'x' });
+    expect(r).toEqual({ ok: true, text: 'x', tokensUsed: 0 });
+  });
+});
+
+describe('createNdjsonLineReader', () => {
+  it('emits each complete line and buffers a partial trailing line until it completes', () => {
+    const lines: string[] = [];
+    const reader = createNdjsonLineReader(l => lines.push(l));
+    reader.push('{"a":1}\n{"b":2}\n{"c"');
+    expect(lines).toEqual(['{"a":1}', '{"b":2}']);
+    reader.push(':3}\n');
+    expect(lines).toEqual(['{"a":1}', '{"b":2}', '{"c":3}']);
+  });
+
+  it('skips blank lines', () => {
+    const lines: string[] = [];
+    const reader = createNdjsonLineReader(l => lines.push(l));
+    reader.push('{"a":1}\n\n\n{"b":2}\n');
+    expect(lines).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  it('handles a single result event arriving split across two chunks at an arbitrary byte offset', () => {
+    const lines: string[] = [];
+    const reader = createNdjsonLineReader(l => lines.push(l));
+    const full = '{"type":"result","result":"hello world"}\n';
+    reader.push(full.slice(0, 20));
+    reader.push(full.slice(20));
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).result).toBe('hello world');
+  });
+});
+
+describe('computeFirstTokenBudgetMs', () => {
+  it('returns exactly the base budget floor for a zero-length prompt', () => {
+    expect(computeFirstTokenBudgetMs(0, 120_000, 420_000)).toBe(120_000);
+  });
+
+  it('adds a small, proportionate amount for a small prompt (never drops below the base)', () => {
+    const result = computeFirstTokenBudgetMs(100, 120_000, 420_000);
+    expect(result).toBeGreaterThanOrEqual(120_000);
+    expect(result).toBeLessThan(120_100); // 100 chars * 0.3ms/char is negligible
+  });
+
+  it('scales up for a large prompt, clamped to the ceiling', () => {
+    // 600,000 chars * 0.3ms/char = 180,000ms added to a 120,000ms base -> 300,000ms, under the 420,000ms ceiling.
+    expect(computeFirstTokenBudgetMs(600_000, 120_000, 420_000)).toBe(300_000);
+  });
+
+  it('clamps at the ceiling for an extremely large prompt', () => {
+    expect(computeFirstTokenBudgetMs(5_000_000, 120_000, 420_000)).toBe(420_000);
+  });
+});
+
+describe('deriveLengthDirective', () => {
+  it('returns nothing for small/default output budgets (the CLI applies no cap, so padding a short task would be pure noise)', () => {
+    expect(deriveLengthDirective(undefined)).toBe('');
+    expect(deriveLengthDirective(4096)).toBe('');
+  });
+
+  it('appends a word-count directive for genuinely long-output tasks', () => {
+    const directive = deriveLengthDirective(16384);
+    expect(directive).toContain('substantial response');
+    expect(directive).toContain(String(Math.round(16384 * 0.75)));
+  });
+});
+
+describe('mapThinkingToMaxThinkingTokens', () => {
+  it('maps each level to its token budget', () => {
+    expect(mapThinkingToMaxThinkingTokens('low')).toBe(1024);
+    expect(mapThinkingToMaxThinkingTokens('medium')).toBe(4096);
+    expect(mapThinkingToMaxThinkingTokens('high')).toBe(16384);
+  });
+
+  it('returns undefined when no thinking level is requested', () => {
+    expect(mapThinkingToMaxThinkingTokens(undefined)).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// claude-cli hardening — streaming/timeout behavior via injected spawn
+// ═══════════════════════════════════════════════════════════
+//
+// Drives the actual private runClaudeCliOnce logic with a fake child
+// process (no real subprocess), so the result-event parsing, error
+// classification, and the #25629 no-natural-exit workaround are covered
+// without needing the real CLI installed/authenticated in CI.
+
+function makeFakeChild() {
+  const child: any = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = new EventEmitter();
+  child.stdin.end = vi.fn();
+  child.killed = false;
+  child.exitCode = null;
+  // Deliberately no .pid — keeps killClaudeCliProcess on the safe,
+  // assertable child.kill() path in tests instead of shelling out to a
+  // real `taskkill` against a made-up PID (which risks a same-run-time
+  // collision with an unrelated real process on the test machine).
+  child.kill = vi.fn(() => { child.killed = true; });
+  return child;
+}
+
+const FAKE_PROVIDER = {
+  id: 'claude-cli',
+  name: 'Claude Code (subscription)',
+  model: 'sonnet',
+  tier: 'free' as const,
+  available: true,
+  endpoint: 'local-cli',
+  maxTokens: 16384,
+  costPer1kInput: 0,
+  costPer1kOutput: 0,
+};
+
+describe('runClaudeCliOnce (streaming behavior, fake spawn)', () => {
+  let vaultDir: string;
+  let vault: Vault;
+  let costs: CostTracker;
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'authoragent-claudecli-test-'));
+    process.env.AUTHORCLAW_VAULT_KEY = 'test-router-key';
+    vault = new Vault(vaultDir);
+    await vault.initialize();
+    costs = new CostTracker({ dailyLimit: 5, monthlyLimit: 50 });
+  });
+
+  afterEach(async () => {
+    delete process.env.AUTHORCLAW_VAULT_KEY;
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('resolves with the parsed text/tokens on a successful result event, and kills the child', async () => {
+    const child = makeFakeChild();
+    const fakeSpawn = vi.fn((_bin: string, _args: string[], _opts?: any) => child);
+    const router = new AIRouter({ 'claude-cli': { enabled: false } }, vault, costs, undefined, { spawn: fakeSpawn as any });
+
+    const promise = (router as any).runClaudeCliOnce(
+      FAKE_PROVIDER,
+      { provider: 'claude-cli', system: 'sys', messages: [{ role: 'user', content: 'hi' }] },
+      Date.now()
+    );
+    await vi.waitFor(() => expect(fakeSpawn).toHaveBeenCalled());
+
+    child.stdout.emit('data', Buffer.from(
+      JSON.stringify({ type: 'result', is_error: false, result: 'hello', usage: { input_tokens: 10, output_tokens: 5 } }) + '\n'
+    ));
+
+    const result = await promise;
+    expect(result).toEqual({ text: 'hello', tokensUsed: 15, estimatedCost: 0, provider: 'claude-cli' });
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  it('rejects with a classified ClaudeCliError on an is_error result event', async () => {
+    const child = makeFakeChild();
+    const fakeSpawn = vi.fn((_bin: string, _args: string[], _opts?: any) => child);
+    const router = new AIRouter({ 'claude-cli': { enabled: false } }, vault, costs, undefined, { spawn: fakeSpawn as any });
+
+    const promise = (router as any).runClaudeCliOnce(
+      FAKE_PROVIDER,
+      { provider: 'claude-cli', system: 'sys', messages: [{ role: 'user', content: 'hi' }] },
+      Date.now()
+    );
+    await vi.waitFor(() => expect(fakeSpawn).toHaveBeenCalled());
+
+    child.stdout.emit('data', Buffer.from(
+      JSON.stringify({ type: 'result', is_error: true, result: '', subtype: 'error_max_turns' }) + '\n'
+    ));
+
+    await expect(promise).rejects.toThrow(ClaudeCliError);
+    await expect(promise).rejects.toMatchObject({ kind: 'fatal' });
+  });
+
+  it('rejects when the child exits without ever producing a result event, classified from stderr', async () => {
+    const child = makeFakeChild();
+    const fakeSpawn = vi.fn((_bin: string, _args: string[], _opts?: any) => child);
+    const router = new AIRouter({ 'claude-cli': { enabled: false } }, vault, costs, undefined, { spawn: fakeSpawn as any });
+
+    const promise = (router as any).runClaudeCliOnce(
+      FAKE_PROVIDER,
+      { provider: 'claude-cli', system: 'sys', messages: [{ role: 'user', content: 'hi' }] },
+      Date.now()
+    );
+    await vi.waitFor(() => expect(fakeSpawn).toHaveBeenCalled());
+
+    child.stderr.emit('data', Buffer.from('Failed to authenticate. OAuth access token has expired.'));
+    child.emit('close', 1, null);
+
+    await expect(promise).rejects.toMatchObject({ kind: 'auth' });
+  });
+
+  it('rejects with a clear message when the binary is not found (ENOENT)', async () => {
+    const child = makeFakeChild();
+    const fakeSpawn = vi.fn((_bin: string, _args: string[], _opts?: any) => child);
+    const router = new AIRouter({ 'claude-cli': { enabled: false } }, vault, costs, undefined, { spawn: fakeSpawn as any });
+
+    const promise = (router as any).runClaudeCliOnce(
+      FAKE_PROVIDER,
+      { provider: 'claude-cli', system: 'sys', messages: [{ role: 'user', content: 'hi' }] },
+      Date.now()
+    );
+    await vi.waitFor(() => expect(fakeSpawn).toHaveBeenCalled());
+
+    child.emit('error', { code: 'ENOENT' });
+
+    await expect(promise).rejects.toThrow(/not found/i);
+  });
+
+  it('refuses to spawn with a suspicious model value instead of passing it through to argv', async () => {
+    const child = makeFakeChild();
+    const fakeSpawn = vi.fn((_bin: string, _args: string[], _opts?: any) => child);
+    const router = new AIRouter({ 'claude-cli': { enabled: false } }, vault, costs, undefined, { spawn: fakeSpawn as any });
+
+    const badProvider = { ...FAKE_PROVIDER, model: 'sonnet && calc' };
+    await expect(
+      (router as any).runClaudeCliOnce(
+        badProvider,
+        { provider: 'claude-cli', system: 'sys', messages: [{ role: 'user', content: 'hi' }] },
+        Date.now()
+      )
+    ).rejects.toThrow(/suspicious model/i);
+    expect(fakeSpawn).not.toHaveBeenCalled();
+  });
+
+  it('writes the system prompt to a temp file referenced in argv, and removes it after the call settles', async () => {
+    const child = makeFakeChild();
+    const fakeSpawn = vi.fn((_bin: string, _args: string[], _opts?: any) => child);
+    const router = new AIRouter({ 'claude-cli': { enabled: false } }, vault, costs, undefined, { spawn: fakeSpawn as any });
+
+    const promise = (router as any).runClaudeCliOnce(
+      FAKE_PROVIDER,
+      { provider: 'claude-cli', system: 'you are a test', messages: [{ role: 'user', content: 'hi' }] },
+      Date.now()
+    );
+    await vi.waitFor(() => expect(fakeSpawn).toHaveBeenCalled());
+
+    const args: string[] = fakeSpawn.mock.calls[0][1];
+    const filePath = args[args.indexOf('--system-prompt-file') + 1];
+    expect(filePath).toMatch(/authoragent-claude-cli/);
+    const { readFile, access } = await import('node:fs/promises');
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('you are a test');
+
+    child.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'ok' }) + '\n'));
+    await promise;
+
+    await expect(access(filePath)).rejects.toThrow(); // cleaned up
+  });
+
+  it('two concurrent calls get distinct temp files, both cleaned up', async () => {
+    const child1 = makeFakeChild();
+    const child2 = makeFakeChild();
+    const children = [child1, child2];
+    const fakeSpawn = vi.fn((_bin: string, _args: string[], _opts?: any) => children.shift());
+    const router = new AIRouter({ 'claude-cli': { enabled: false } }, vault, costs, undefined, { spawn: fakeSpawn as any });
+
+    const p1 = (router as any).runClaudeCliOnce(
+      FAKE_PROVIDER, { provider: 'claude-cli', system: 'sys A', messages: [{ role: 'user', content: 'hi' }] }, Date.now()
+    );
+    const p2 = (router as any).runClaudeCliOnce(
+      FAKE_PROVIDER, { provider: 'claude-cli', system: 'sys B', messages: [{ role: 'user', content: 'hi' }] }, Date.now()
+    );
+    await vi.waitFor(() => expect(fakeSpawn).toHaveBeenCalledTimes(2));
+
+    const args1: string[] = fakeSpawn.mock.calls[0][1];
+    const args2: string[] = fakeSpawn.mock.calls[1][1];
+    const file1 = args1[args1.indexOf('--system-prompt-file') + 1];
+    const file2 = args2[args2.indexOf('--system-prompt-file') + 1];
+    expect(file1).not.toBe(file2);
+
+    child1.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'A' }) + '\n'));
+    child2.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'B' }) + '\n'));
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.text).toBe('A');
+    expect(r2.text).toBe('B');
+
+    const { access } = await import('node:fs/promises');
+    await expect(access(file1)).rejects.toThrow();
+    await expect(access(file2)).rejects.toThrow();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// getFallbackProvider — same-transport fix
+// ═══════════════════════════════════════════════════════════
+//
+// claude-cli and claude-cli-opus share one binary/token/rate-limiter.
+// Production logs showed a claude-cli auth failure immediately followed by
+// the identical failure on claude-cli-opus — the "fallback" was a retry of
+// the same broken transport. These insert synthetic provider entries
+// directly (bypassing the real CLI probe in initialize()) for a fast,
+// deterministic unit test.
+
+describe('getFallbackProvider (claude-cli same-transport fix)', () => {
+  let vaultDir: string;
+  let vault: Vault;
+  let costs: CostTracker;
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'authoragent-fallback-test-'));
+    process.env.AUTHORCLAW_VAULT_KEY = 'test-router-key';
+    vault = new Vault(vaultDir);
+    await vault.initialize();
+    costs = new CostTracker({ dailyLimit: 5, monthlyLimit: 50 });
+  });
+
+  afterEach(async () => {
+    delete process.env.AUTHORCLAW_VAULT_KEY;
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  function registerFakeClaudeCli(router: AIRouter) {
+    const providers = (router as any).providers as Map<string, any>;
+    providers.set('claude-cli', { ...FAKE_PROVIDER });
+    providers.set('claude-cli-opus', { ...FAKE_PROVIDER, id: 'claude-cli-opus', model: 'opus' });
+  }
+
+  it('never returns claude-cli-opus as the fallback for a failed claude-cli call', async () => {
+    const router = new AIRouter({ ollama: { enabled: false } }, vault, costs);
+    await router.initialize();
+    registerFakeClaudeCli(router);
+    expect(router.getFallbackProvider('claude-cli')).toBeNull();
+  });
+
+  it('never returns claude-cli as the fallback for a failed claude-cli-opus call', async () => {
+    const router = new AIRouter({ ollama: { enabled: false } }, vault, costs);
+    await router.initialize();
+    registerFakeClaudeCli(router);
+    expect(router.getFallbackProvider('claude-cli-opus')).toBeNull();
+  });
+
+  it('falls through to a genuinely different provider when one is available', async () => {
+    await vault.set('gemini_api_key', 'k1');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('no network in tests')));
+    const router = new AIRouter({ ollama: { enabled: false } }, vault, costs);
+    await router.initialize();
+    registerFakeClaudeCli(router);
+    expect(router.getFallbackProvider('claude-cli')?.id).toBe('gemini');
+    vi.unstubAllGlobals();
+  });
+
+  it('an explicit preferredProviderFallback pointing at the same transport is ignored', async () => {
+    await vault.set('gemini_api_key', 'k1');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('no network in tests')));
+    const router = new AIRouter({ ollama: { enabled: false } }, vault, costs);
+    await router.initialize();
+    registerFakeClaudeCli(router);
+    router.setGlobalPreferredProviderFallback('claude-cli-opus'); // same transport as claude-cli
+    // Falls through to the free/paid heuristic instead of the (same-transport) configured fallback.
+    expect(router.getFallbackProvider('claude-cli')?.id).toBe('gemini');
+    vi.unstubAllGlobals();
   });
 });

--- a/gateway/src/ai/router.test.ts
+++ b/gateway/src/ai/router.test.ts
@@ -851,41 +851,46 @@ describe('runClaudeCliOnce (streaming behavior, fake spawn)', () => {
   });
 
   it('two concurrent calls get distinct temp files, both cleaned up', async () => {
-    vi.useFakeTimers();
-    try {
-      const child1 = makeFakeChild();
-      const child2 = makeFakeChild();
-      const children = [child1, child2];
-      const fakeSpawn = vi.fn((_bin: string, _args: string[], _opts?: any) => children.shift());
-      const router = new AIRouter({ 'claude-cli': { enabled: false } }, vault, costs, undefined, { spawn: fakeSpawn as any });
+    // writeSystemPromptFile does a real fs write before spawning, so which of
+    // the two calls reaches spawnFn first is a genuine (and irrelevant) race —
+    // fake timers don't control real I/O. Route each fake child by reading
+    // back which system prompt its temp file actually holds, rather than
+    // assuming spawn call order matches invocation order.
+    // spawnFn must return synchronously (real child_process.spawn does), and
+    // the prompt file is already fully written by the time spawnFn runs
+    // (writeSystemPromptFile is awaited beforehand), so a sync read is safe.
+    const { readFileSync } = await import('node:fs');
+    const childA = makeFakeChild();
+    const childB = makeFakeChild();
+    const fakeSpawn = vi.fn((_bin: string, args: string[], _opts?: any) => {
+      const filePath = args[args.indexOf('--system-prompt-file') + 1];
+      const content = readFileSync(filePath, 'utf8');
+      return content.includes('sys A') ? childA : childB;
+    });
+    const router = new AIRouter({ 'claude-cli': { enabled: false } }, vault, costs, undefined, { spawn: fakeSpawn as any });
 
-      const p1 = (router as any).runClaudeCliOnce(
-        FAKE_PROVIDER, { provider: 'claude-cli', system: 'sys A', messages: [{ role: 'user', content: 'hi' }] }, Date.now()
-      );
-      const p2 = (router as any).runClaudeCliOnce(
-        FAKE_PROVIDER, { provider: 'claude-cli', system: 'sys B', messages: [{ role: 'user', content: 'hi' }] }, Date.now()
-      );
-      await vi.waitFor(() => expect(fakeSpawn).toHaveBeenCalledTimes(2));
+    const p1 = (router as any).runClaudeCliOnce(
+      FAKE_PROVIDER, { provider: 'claude-cli', system: 'sys A', messages: [{ role: 'user', content: 'hi' }] }, Date.now()
+    );
+    const p2 = (router as any).runClaudeCliOnce(
+      FAKE_PROVIDER, { provider: 'claude-cli', system: 'sys B', messages: [{ role: 'user', content: 'hi' }] }, Date.now()
+    );
+    await vi.waitFor(() => expect(fakeSpawn).toHaveBeenCalledTimes(2));
 
-      const args1: string[] = fakeSpawn.mock.calls[0][1];
-      const args2: string[] = fakeSpawn.mock.calls[1][1];
-      const file1 = args1[args1.indexOf('--system-prompt-file') + 1];
-      const file2 = args2[args2.indexOf('--system-prompt-file') + 1];
-      expect(file1).not.toBe(file2);
+    const files = fakeSpawn.mock.calls.map(([, args]: [string, string[]]) => args[args.indexOf('--system-prompt-file') + 1]);
+    const [file1, file2] = files;
+    expect(file1).not.toBe(file2);
 
-      child1.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'A' }) + '\n'));
-      child2.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'B' }) + '\n'));
+    childA.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'A' }) + '\n'));
+    childB.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'result', is_error: false, result: 'B' }) + '\n'));
 
-      const [r1, r2] = await Promise.all([p1, p2]);
-      expect(r1.text).toBe('A');
-      expect(r2.text).toBe('B');
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.text).toBe('A');
+    expect(r2.text).toBe('B');
 
-      const { access } = await import('node:fs/promises');
-      await expect(access(file1)).rejects.toThrow();
-      await expect(access(file2)).rejects.toThrow();
-    } finally {
-      vi.useRealTimers();
-    }
+    const { access } = await import('node:fs/promises');
+    await expect(access(file1)).rejects.toThrow();
+    await expect(access(file2)).rejects.toThrow();
   });
 });
 

--- a/gateway/src/ai/router.ts
+++ b/gateway/src/ai/router.ts
@@ -5,11 +5,15 @@
  */
 
 import { createHash } from 'crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { Vault } from '../security/vault.js';
 import { CostTracker } from '../services/costs.js';
 import { logger } from '../services/logger.js';
 import { getLLMPrice } from '../services/pricing.js';
 import { ModelConfig } from './model-config.js';
+
+const execFileAsync = promisify(execFile);
 
 const log = logger.child('[router]');
 
@@ -166,6 +170,18 @@ const PROVIDER_DEFAULTS: Record<string, ProviderDefault> = {
   claude:     { defaultModel: 'claude-sonnet-4-5-20250929',    tier: 'paid',  costPer1kInput: 0.003,   costPer1kOutput: 0.015 },
   openai:     { defaultModel: 'gpt-4o',                        tier: 'paid',  costPer1kInput: 0.0025,  costPer1kOutput: 0.01 },
   openrouter: { defaultModel: 'anthropic/claude-sonnet-4-5',   tier: 'cheap', costPer1kInput: 0.003,   costPer1kOutput: 0.015 },
+  // Rides a Claude Code CLI session (claude.ai OAuth login, e.g. Pro/Max
+  // subscription) instead of a metered Anthropic API key. No separate
+  // per-token bill, so cost is modeled as free — the CLI's own
+  // total_cost_usd is an internal Anthropic estimate, not something
+  // AuthorAgent gets billed for on top of the subscription.
+  'claude-cli': { defaultModel: 'sonnet',                      tier: 'free',  costPer1kInput: 0,       costPer1kOutput: 0 },
+  // Same CLI session, pinned to the opus alias. Not a separately configured
+  // provider in the settings UI — selectProvider() swaps to this id for the
+  // handful of task types where prose quality matters more than quota
+  // headroom (see CLAUDE_CLI_PREMIUM_TASKS below). Everything else stays on
+  // the sonnet-backed 'claude-cli' id.
+  'claude-cli-opus': { defaultModel: 'opus',                   tier: 'free',  costPer1kInput: 0,       costPer1kOutput: 0 },
 };
 
 /** Known model slugs per provider, for a settings dropdown. Free-text custom
@@ -178,7 +194,85 @@ export const KNOWN_MODELS: Record<string, string[]> = {
   claude:   ['claude-sonnet-4-5-20250929', 'claude-sonnet-5', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-fable-5', 'claude-haiku-4-5'],
   openai:   ['gpt-4o', 'gpt-4o-mini', 'gpt-5', 'gpt-5-mini', 'o3', 'o4-mini'],
   openrouter: ['anthropic/claude-sonnet-4-5', 'anthropic/claude-opus-4-8', 'openai/gpt-4o', 'google/gemini-2.5-pro', 'meta-llama/llama-3.1-70b-instruct'],
+  // CLI accepts aliases (always the latest of each tier) or full model names.
+  'claude-cli': ['sonnet', 'opus', 'haiku', 'fable'],
+  'claude-cli-opus': ['opus'],
 };
+
+/**
+ * Task types that get bumped from the default claude-cli model (sonnet) to
+ * the opus variant when claude-cli is the effective provider. Kept to a
+ * short list deliberately — Opus burns through subscription usage caps
+ * faster than Sonnet, so this is reserved for prose quality (drafting) and
+ * the final polish pass, not every task that happens to route through
+ * claude-cli.
+ */
+const CLAUDE_CLI_PREMIUM_TASKS = new Set(['creative_writing', 'final_edit']);
+
+// ═══════════════════════════════════════════════════════════
+// Claude Code CLI provider helpers
+// ═══════════════════════════════════════════════════════════
+
+/**
+ * A counting semaphore bounding how many `claude -p` child processes can run
+ * at once. Each call spawns a full CLI session (its own auth check, model
+ * session, etc.) — firing a dozen at once both hammers the local machine and
+ * trips Claude Code's own rate limiter, which then fails every in-flight call
+ * simultaneously instead of queueing cleanly. Configured via
+ * config.ai['claude-cli'].maxConcurrent (config/default.json, overridable in
+ * config/user.json — same pattern as ollama.endpoint), default 2.
+ */
+class Semaphore {
+  private queue: Array<() => void> = [];
+  private active = 0;
+
+  constructor(private max: number) {}
+
+  setMax(max: number): void {
+    this.max = max;
+  }
+
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.active >= this.max) {
+      await new Promise<void>(resolve => this.queue.push(resolve));
+    }
+    this.active++;
+    try {
+      return await fn();
+    } finally {
+      this.active--;
+      const next = this.queue.shift();
+      if (next) next();
+    }
+  }
+}
+
+/**
+ * The CLI's `--output-format json` shape isn't a versioned public contract —
+ * it's whatever the current `claude` build happens to emit. Pinning a
+ * known-good minimum version means a schema change surfaces as a clear
+ * "please update" error instead of a silent parse failure mid-pipeline.
+ * Bump after manually verifying `claude -p "hi" --output-format json` still
+ * returns the `{ result, usage: { input_tokens, output_tokens } }` shape
+ * this adapter expects.
+ */
+const MIN_CLAUDE_CLI_VERSION = '2.0.0';
+
+function parseSemver(v: string): [number, number, number] | null {
+  const m = v.trim().match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function versionAtLeast(actual: string, min: string): boolean {
+  const a = parseSemver(actual);
+  const b = parseSemver(min);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] > b[i];
+  }
+  return true;
+}
 
 // ═══════════════════════════════════════════════════════════
 // AI Router
@@ -190,6 +284,10 @@ export class AIRouter {
   private vault: Vault;
   private costs: CostTracker;
   private globalPreferredProvider: string | null = null;
+  // Tried when globalPreferredProvider (or a per-call preferredId) is
+  // configured but currently unavailable — e.g. "try openai, and if it's not
+  // reachable, use claude-cli" instead of silently dropping to tier routing.
+  private globalPreferredProviderFallback: string | null = null;
   private modelConfig: ModelConfig | null = null;
 
   // ── Prompt Cache ──
@@ -199,6 +297,12 @@ export class AIRouter {
   private cacheHits = 0;
   private cacheMisses = 0;
   private savedTokens = 0;
+
+  // ── Claude Code CLI provider state ──
+  // Concurrency cap: config.ai['claude-cli'].maxConcurrent, default 2. Read
+  // again in initialize() in case config was reloaded/reinitialized.
+  private claudeCliSemaphore = new Semaphore(2);
+  private claudeCliVersion: string | null = null;
 
   constructor(config: any, vault: Vault, costs: CostTracker, workspaceDir?: string) {
     this.config = config;
@@ -210,6 +314,7 @@ export class AIRouter {
     if (workspaceDir) {
       this.modelConfig = new ModelConfig(workspaceDir);
     }
+    this.claudeCliSemaphore.setMax(this.config?.['claude-cli']?.maxConcurrent ?? 2);
   }
 
   /**
@@ -332,13 +437,32 @@ export class AIRouter {
     if (openaiKey) {
       const model = this.resolveModel('openai', PROVIDER_DEFAULTS.openai.defaultModel);
       const price = this.priceFor('openai', model);
+      const endpoint = this.config.openai?.endpoint || 'https://api.openai.com/v1';
+      // Custom/local endpoints (LM Studio, vLLM, llama.cpp server, etc.) can
+      // be offline without any config change — e.g. LM Studio simply not
+      // running. Probe reachability the same way checkOllama() does, so
+      // `available` reflects reality and selectProvider()'s preferred-
+      // fallback swap can act immediately instead of only after a slow
+      // connection-timeout failure on a live call. Skipped for the default
+      // api.openai.com endpoint — that's Anthropic-grade infra, not worth
+      // an extra startup round-trip to probe.
+      let reachable = true;
+      if (this.config.openai?.endpoint) {
+        reachable = await this.checkOpenAICompatible(endpoint);
+        if (!reachable) {
+          log.warn(`openai endpoint ${endpoint} not reachable at startup — marking unavailable until next reinitialize`);
+        }
+      }
       this.providers.set('openai', {
         id: 'openai',
         name: 'OpenAI GPT',
         model,
         tier: 'paid',
-        available: true,
-        endpoint: 'https://api.openai.com/v1',
+        available: reachable,
+        // Configurable so this provider slot can also point at any
+        // OpenAI-compatible local server (LM Studio, vLLM, llama.cpp server,
+        // text-generation-webui, etc.) — same override pattern as Ollama above.
+        endpoint,
         maxTokens: 16384, // GPT-4o + GPT-4o-mini support 16K output tokens
         costPer1kInput: price.costPer1kInput,
         costPer1kOutput: price.costPer1kOutput,
@@ -372,6 +496,95 @@ export class AIRouter {
         costPer1kOutput: price.costPer1kOutput,
       });
     }
+
+    // ── Claude Code CLI (FREE — rides your claude.ai subscription login) ──
+    // Opt-in: off by default since it depends on a local CLI + interactive
+    // login rather than a portable API key. Enable with
+    // config.ai['claude-cli'].enabled = true once `claude login` has been run.
+    if (this.config['claude-cli']?.enabled === true) {
+      // Re-read maxConcurrent in case config changed since construction
+      // (reinitialize() runs this again without recreating the router).
+      this.claudeCliSemaphore.setMax(this.config['claude-cli']?.maxConcurrent ?? 2);
+
+      const probe = await this.checkClaudeCLI();
+      if (probe.available) {
+        const model = this.resolveModel('claude-cli', PROVIDER_DEFAULTS['claude-cli'].defaultModel);
+        this.providers.set('claude-cli', {
+          id: 'claude-cli',
+          name: 'Claude Code (subscription)',
+          model,
+          tier: 'free',
+          available: true,
+          endpoint: 'local-cli',
+          maxTokens: 16384,
+          costPer1kInput: 0,
+          costPer1kOutput: 0,
+        });
+
+        // Opus variant — same CLI session, model pinned to 'opus'. Registered
+        // whenever the base claude-cli probe succeeds; selectProvider() is
+        // what decides whether a given task actually gets routed here.
+        const opusModel = this.resolveModel('claude-cli-opus', PROVIDER_DEFAULTS['claude-cli-opus'].defaultModel);
+        this.providers.set('claude-cli-opus', {
+          id: 'claude-cli-opus',
+          name: 'Claude Code (subscription, opus)',
+          model: opusModel,
+          tier: 'free',
+          available: true,
+          endpoint: 'local-cli',
+          maxTokens: 16384,
+          costPer1kInput: 0,
+          costPer1kOutput: 0,
+        });
+      } else {
+        log.warn(`claude-cli unavailable: ${probe.reason}`);
+      }
+    }
+  }
+
+  /**
+   * Probe the local Claude Code CLI: installed, new enough, and logged in.
+   * Mirrors checkOllama()'s "reachable or not" pattern but with richer
+   * diagnostics since failures here are usually one-time setup issues
+   * (install / update / login) rather than transient network blips.
+   */
+  private async checkClaudeCLI(): Promise<{ available: boolean; version?: string; reason?: string }> {
+    let version: string;
+    try {
+      const { stdout } = await execFileAsync('claude', ['--version'], { timeout: 10_000 });
+      version = stdout.trim();
+      this.claudeCliVersion = version;
+    } catch (err: any) {
+      if (err?.code === 'ENOENT') {
+        return { available: false, reason: 'Claude Code CLI not found on PATH. Install it first.' };
+      }
+      return { available: false, reason: `Claude Code CLI check failed: ${err?.message || err}` };
+    }
+
+    if (!versionAtLeast(version, MIN_CLAUDE_CLI_VERSION)) {
+      return {
+        available: false,
+        version,
+        reason: `Claude Code CLI ${version} is older than the minimum tested version ` +
+                 `${MIN_CLAUDE_CLI_VERSION}. Run "claude update" before enabling this provider.`,
+      };
+    }
+
+    try {
+      const { stdout } = await execFileAsync('claude', ['auth', 'status'], { timeout: 10_000 });
+      const status = JSON.parse(stdout);
+      if (!status?.loggedIn) {
+        return { available: false, version, reason: 'Claude Code CLI is installed but not logged in. Run "claude login".' };
+      }
+    } catch (err: any) {
+      return {
+        available: false,
+        version,
+        reason: `Could not confirm Claude Code CLI login status: ${err?.message || err}. Run "claude login".`,
+      };
+    }
+
+    return { available: true, version };
   }
 
   /**
@@ -462,6 +675,22 @@ export class AIRouter {
   }
 
   /**
+   * Reachability probe for a custom OpenAI-compatible endpoint (LM Studio,
+   * vLLM, etc.) — GET /models is the de facto standard health-check route
+   * across these servers. Same 3s-timeout pattern as checkOllama().
+   */
+  private async checkOpenAICompatible(endpoint: string): Promise<boolean> {
+    try {
+      const response = await fetch(`${endpoint}/models`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Set or clear the global preferred provider.
    * When set, this provider is tried first for ALL tasks before tier routing.
    */
@@ -474,14 +703,48 @@ export class AIRouter {
   }
 
   /**
+   * Set (or clear) the fallback provider used when the primary preference
+   * (global or per-call) is configured but not currently available.
+   */
+  setGlobalPreferredProviderFallback(providerId: string | null): void {
+    this.globalPreferredProviderFallback = providerId;
+  }
+
+  getGlobalPreferredProviderFallback(): string | null {
+    return this.globalPreferredProviderFallback;
+  }
+
+  /**
    * Select the best provider for a given task type using tiered routing.
-   * Priority: per-project override → global preference → tier routing.
-   * When a preferred provider is set, it is ALWAYS used if available,
-   * regardless of task tier.
+   * Priority: per-project override → global preference → preferred fallback
+   * → tier routing. When a preferred provider is set, it is ALWAYS used if
+   * available, regardless of task tier.
    */
   selectProvider(taskType: string, preferredId?: string): AIProvider {
     // Resolve effective preference: per-project > global
-    const effectivePref = preferredId || this.globalPreferredProvider;
+    let effectivePref = preferredId || this.globalPreferredProvider;
+
+    // Preferred-provider fallback: the primary preference is configured but
+    // not currently reachable (server down, no key, CLI not logged in) —
+    // e.g. "try openai, and if it's not available, use claude-cli" instead
+    // of silently dropping straight to tier routing.
+    if (effectivePref && !this.providers.get(effectivePref)?.available &&
+        this.globalPreferredProviderFallback && this.globalPreferredProviderFallback !== effectivePref) {
+      log.warn(`Preferred provider '${effectivePref}' not available, using configured fallback '${this.globalPreferredProviderFallback}'`);
+      effectivePref = this.globalPreferredProviderFallback;
+    }
+
+    // claude-cli premium-task bump: when claude-cli is the effective
+    // preference and this task is prose-quality-sensitive (drafting, final
+    // polish), swap to the opus-pinned variant if it's available. Falls
+    // through to plain claude-cli (sonnet) otherwise — this only ever
+    // affects users who've explicitly set claude-cli as their provider.
+    if (effectivePref === 'claude-cli' && CLAUDE_CLI_PREMIUM_TASKS.has(taskType)) {
+      const opus = this.providers.get('claude-cli-opus');
+      if (opus?.available) {
+        effectivePref = 'claude-cli-opus';
+      }
+    }
 
     if (effectivePref) {
       const pref = this.providers.get(effectivePref);
@@ -519,11 +782,22 @@ export class AIRouter {
   }
 
   /**
-   * Get fallback provider if primary fails.
+   * Get fallback provider if primary fails (live call error, not just
+   * unavailable-at-selection-time — see selectProvider() for that case).
    * Respects the budget cap — skips paid providers when the user is over budget,
    * preferring free providers (Ollama, Gemini free tier) instead.
    */
   getFallbackProvider(currentId: string): AIProvider | null {
+    // Explicit preferred fallback takes priority over the generic free/paid
+    // heuristic below — e.g. "openai's live call just failed, go straight to
+    // claude-cli" instead of whatever happens to be first by insertion order.
+    if (this.globalPreferredProviderFallback && this.globalPreferredProviderFallback !== currentId) {
+      const configured = this.providers.get(this.globalPreferredProviderFallback);
+      if (configured?.available) {
+        return configured;
+      }
+    }
+
     const overBudget = this.costs?.isOverBudget?.() ?? false;
     // Prefer free providers first so we don't silently burn budget on fallback.
     const freeProviders: AIProvider[] = [];
@@ -571,6 +845,9 @@ export class AIRouter {
         return this.completeOpenAICompatible(provider, request, 'deepseek_api_key');
       case 'claude':
         return this.completeClaude(provider, request);
+      case 'claude-cli':
+      case 'claude-cli-opus':
+        return this.completeClaudeCode(provider, request);
       case 'openai':
         return this.completeOpenAICompatible(provider, request, 'openai_api_key');
       case 'openrouter':
@@ -798,6 +1075,123 @@ export class AIRouter {
       estimatedCost: (inputTokens / 1000) * provider.costPer1kInput +
                      (outputTokens / 1000) * provider.costPer1kOutput,
       provider: 'claude',
+    };
+  }
+
+  // ── Claude Code CLI (subscription-backed, no metered API key) ──
+  //
+  // CAVEATS:
+  //  - Claude Code's rate limits/usage caps are tuned for interactive coding
+  //    sessions, not a pipeline firing 20-30 chapter-length calls per book.
+  //    Keep maxConcurrent low (config.ai['claude-cli'].maxConcurrent) and
+  //    expect throttling on long "Full Book" runs.
+  //  - Single-shot only: `claude -p` isn't a multi-turn chat API, so the
+  //    message history below is flattened into one prompt.
+  //  - No thinking-budget passthrough — Claude Code manages its own
+  //    reasoning internally; request.thinking is accepted but ignored here.
+  private async completeClaudeCode(
+    provider: AIProvider,
+    request: CompletionRequest
+  ): Promise<CompletionResponse> {
+    return this.claudeCliSemaphore.run(() => this.runClaudeCliOnce(provider, request));
+  }
+
+  private async runClaudeCliOnce(
+    provider: AIProvider,
+    request: CompletionRequest
+  ): Promise<CompletionResponse> {
+    const transcript = request.messages
+      .map(m => `${m.role === 'assistant' ? 'Assistant' : 'User'}: ${m.content}`)
+      .join('\n\n');
+    const prompt = `${request.system}\n\n${transcript}`;
+
+    // Output-heavy tasks (full chapter drafts, 20-30 chapter outlines — up to
+    // TASK_OUTPUT_BUDGET's 16384 tokens) can genuinely take longer than a
+    // flat 120s to stream through the CLI wrapper, especially on opus. This
+    // was the actual root cause of "Claude Code CLI call timed out after
+    // 120s" on otherwise-healthy accounts: not a hang, just not enough time.
+    // Configurable via config.ai['claude-cli'].timeoutMs (default 300s).
+    const timeoutMs = this.config?.['claude-cli']?.timeoutMs ?? 300_000;
+
+    let stdout: string;
+    try {
+      // execFile (not exec/shell) — no shell interpolation. The prompt is
+      // NOT passed as an argv element: AuthorAgent's system prompt (soul +
+      // memory + context) routinely runs many KB, and on Windows the CLI is
+      // invoked through a shim whose effective command-line length caps out
+      // around 8K chars — a long prompt-as-argument blows past that and
+      // fails with "spawn ENAMETOOLONG" before the process even starts.
+      // Piping the prompt over stdin instead sidesteps the OS command-line
+      // limit entirely (verified against a 20K-char prompt).
+      const child = execFileAsync(
+        'claude',
+        ['-p', '--output-format', 'json', '--model', provider.model],
+        { timeout: timeoutMs, maxBuffer: 32 * 1024 * 1024 }
+      );
+      child.child.stdin!.end(prompt);
+      const result = await child;
+      stdout = result.stdout;
+    } catch (err: any) {
+      if (err?.code === 'ENOENT') {
+        throw new Error(`Claude Code CLI not found. Install it and run "claude login".`);
+      }
+      if (err?.code === 'ENAMETOOLONG') {
+        throw new Error(`Claude Code CLI error: prompt too long even for stdin. This shouldn't happen — please report it.`);
+      }
+      if (err?.killed || err?.signal === 'SIGTERM') {
+        throw new Error(`Claude Code CLI call timed out after ${Math.round(timeoutMs / 1000)}s.`);
+      }
+      const stderr = String(err?.stderr || '').toLowerCase();
+      if (stderr.includes('not logged in') || stderr.includes('authentication')) {
+        throw new Error(`Claude Code CLI is not authenticated. Run "claude login" first.`);
+      }
+      throw new Error(`Claude Code CLI error: ${err?.stderr || err?.message || err}`);
+    }
+
+    // ── Parse, with a fallback for schema drift ──
+    // Preferred path: --output-format json gives { result, usage }. Fallback:
+    // if JSON.parse fails (CLI version mismatch, a stray status line before
+    // the JSON blob, or a future format change), scan for the last
+    // JSON-looking blob; if that also fails, fall back to raw stdout as
+    // plain text rather than failing the whole call outright.
+    let text: string;
+    let usage: { input_tokens?: number; output_tokens?: number } | undefined;
+
+    try {
+      const data = JSON.parse(stdout);
+      text = data?.result ?? data?.text ?? '';
+      usage = data?.usage;
+      if (!text) throw new Error('parsed JSON had no result/text field');
+    } catch {
+      const lastBrace = stdout.lastIndexOf('{');
+      if (lastBrace >= 0) {
+        try {
+          const data = JSON.parse(stdout.slice(lastBrace));
+          text = data?.result ?? data?.text ?? '';
+          usage = data?.usage;
+        } catch {
+          text = stdout.trim();
+        }
+      } else {
+        text = stdout.trim();
+      }
+
+      if (!text) {
+        throw new Error(
+          `Claude Code CLI output didn't match the expected JSON shape and had no ` +
+          `usable fallback text. CLI version: ${this.claudeCliVersion ?? 'unknown'}. ` +
+          `Raw output (truncated): ${stdout.slice(0, 300)}`
+        );
+      }
+    }
+
+    return {
+      text,
+      tokensUsed: (usage?.input_tokens ?? 0) + (usage?.output_tokens ?? 0),
+      // Rides the subscription — no separate metered cost to the user, even
+      // though the CLI's own JSON includes an internal total_cost_usd estimate.
+      estimatedCost: 0,
+      provider: provider.id, // 'claude-cli' or 'claude-cli-opus'
     };
   }
 

--- a/gateway/src/ai/router.ts
+++ b/gateway/src/ai/router.ts
@@ -5,7 +5,7 @@
  */
 
 import { createHash } from 'crypto';
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { Vault } from '../security/vault.js';
 import { CostTracker } from '../services/costs.js';
@@ -230,6 +230,11 @@ class Semaphore {
 
   setMax(max: number): void {
     this.max = max;
+  }
+
+  /** For diagnostics: how many calls are currently running vs. waiting for a slot. */
+  debugState(): string {
+    return `active=${this.active}/${this.max} queued=${this.queue.length}`;
   }
 
   async run<T>(fn: () => Promise<T>): Promise<T> {
@@ -1096,6 +1101,33 @@ export class AIRouter {
     return this.claudeCliSemaphore.run(() => this.runClaudeCliOnce(provider, request));
   }
 
+  /**
+   * Runs `claude -p` in STREAMING mode and times it out on INACTIVITY, not
+   * total duration.
+   *
+   * Why: output-heavy tasks (full chapter drafts, 20-30 chapter outlines —
+   * up to TASK_OUTPUT_BUDGET's 16384 tokens) can legitimately take 5-10+
+   * minutes of steady token production through the CLI wrapper. A flat
+   * overall-duration timeout (previously 120s, then 300s) can't distinguish
+   * "still working, just slow" from "genuinely stuck" — it just kills
+   * whichever one happens to still be running when the clock runs out.
+   * Measured in production: one 24K-char-prompt call legitimately took
+   * 296.7s (just under the old 300s cap); a 20K-char-prompt call was killed
+   * at exactly 300s while (per this same logging) still producing output.
+   *
+   * The fix: `--output-format stream-json` emits one JSON object per line as
+   * the response is generated. We track the last time ANY data arrived and
+   * only kill the process if that goes quiet for `inactivityTimeoutMs` —
+   * so a slow-but-steady multi-minute generation is never killed early, but
+   * a genuine hang (no bytes at all) is caught quickly. `maxTimeoutMs` is a
+   * separate, generous absolute backstop against a truly runaway call.
+   *
+   * We also do NOT wait for the child process to exit naturally: resolve as
+   * soon as the `{"type":"result",...}` event is seen, then kill the
+   * process ourselves. This works around a confirmed upstream bug
+   * (anthropics/claude-code#25629) where stream-json mode can hang
+   * indefinitely *after* emitting the result event instead of exiting.
+   */
   private async runClaudeCliOnce(
     provider: AIProvider,
     request: CompletionRequest
@@ -1105,94 +1137,153 @@ export class AIRouter {
       .join('\n\n');
     const prompt = `${request.system}\n\n${transcript}`;
 
-    // Output-heavy tasks (full chapter drafts, 20-30 chapter outlines — up to
-    // TASK_OUTPUT_BUDGET's 16384 tokens) can genuinely take longer than a
-    // flat 120s to stream through the CLI wrapper, especially on opus. This
-    // was the actual root cause of "Claude Code CLI call timed out after
-    // 120s" on otherwise-healthy accounts: not a hang, just not enough time.
-    // Configurable via config.ai['claude-cli'].timeoutMs (default 300s).
-    const timeoutMs = this.config?.['claude-cli']?.timeoutMs ?? 300_000;
+    const inactivityTimeoutMs = this.config?.['claude-cli']?.inactivityTimeoutMs ?? 90_000;
+    const maxTimeoutMs = this.config?.['claude-cli']?.maxTimeoutMs ?? 900_000;
 
-    let stdout: string;
-    try {
-      // execFile (not exec/shell) — no shell interpolation. The prompt is
-      // NOT passed as an argv element: AuthorAgent's system prompt (soul +
-      // memory + context) routinely runs many KB, and on Windows the CLI is
-      // invoked through a shim whose effective command-line length caps out
-      // around 8K chars — a long prompt-as-argument blows past that and
-      // fails with "spawn ENAMETOOLONG" before the process even starts.
-      // Piping the prompt over stdin instead sidesteps the OS command-line
-      // limit entirely (verified against a 20K-char prompt).
-      const child = execFileAsync(
+    const startedAt = Date.now();
+    log.info(
+      `[claude-cli] spawning: model=${provider.model} promptChars=${prompt.length} ` +
+      `inactivityTimeoutMs=${inactivityTimeoutMs} maxTimeoutMs=${maxTimeoutMs} ` +
+      `activeSemaphoreSlots=${this.claudeCliSemaphore.debugState()}`
+    );
+
+    return new Promise<CompletionResponse>((resolve, reject) => {
+      // spawn (not execFile) — no shell interpolation, same as before. We
+      // need direct stream access here rather than a promise-on-exit, so we
+      // can react to data as it arrives instead of waiting for the process
+      // to finish (which, per the bug above, may never happen naturally).
+      //
+      // --max-turns: generous, not 1. AuthorAgent's system prompt has the
+      // model check Book Bible / style guide / voice profile / outline
+      // before writing (write skill) — each of those can be a tool call,
+      // consuming a "turn" before the actual text response. A cap of 1
+      // aborted those with subtype "error_max_turns" and an empty result
+      // (caught live: audit log showed exactly this). 12 leaves comfortable
+      // room for that context-gathering while still bounding a genuinely
+      // runaway agentic loop.
+      const child = spawn(
         'claude',
-        ['-p', '--output-format', 'json', '--model', provider.model],
-        { timeout: timeoutMs, maxBuffer: 32 * 1024 * 1024 }
+        ['-p', '--output-format', 'stream-json', '--verbose', '--max-turns', '12', '--model', provider.model],
+        { stdio: ['pipe', 'pipe', 'pipe'] }
       );
-      child.child.stdin!.end(prompt);
-      const result = await child;
-      stdout = result.stdout;
-    } catch (err: any) {
-      if (err?.code === 'ENOENT') {
-        throw new Error(`Claude Code CLI not found. Install it and run "claude login".`);
-      }
-      if (err?.code === 'ENAMETOOLONG') {
-        throw new Error(`Claude Code CLI error: prompt too long even for stdin. This shouldn't happen — please report it.`);
-      }
-      if (err?.killed || err?.signal === 'SIGTERM') {
-        throw new Error(`Claude Code CLI call timed out after ${Math.round(timeoutMs / 1000)}s.`);
-      }
-      const stderr = String(err?.stderr || '').toLowerCase();
-      if (stderr.includes('not logged in') || stderr.includes('authentication')) {
-        throw new Error(`Claude Code CLI is not authenticated. Run "claude login" first.`);
-      }
-      throw new Error(`Claude Code CLI error: ${err?.stderr || err?.message || err}`);
-    }
 
-    // ── Parse, with a fallback for schema drift ──
-    // Preferred path: --output-format json gives { result, usage }. Fallback:
-    // if JSON.parse fails (CLI version mismatch, a stray status line before
-    // the JSON blob, or a future format change), scan for the last
-    // JSON-looking blob; if that also fails, fall back to raw stdout as
-    // plain text rather than failing the whole call outright.
-    let text: string;
-    let usage: { input_tokens?: number; output_tokens?: number } | undefined;
+      let stdoutBuf = '';
+      let stderrBuf = '';
+      let settled = false;
+      let lastActivity = Date.now();
 
-    try {
-      const data = JSON.parse(stdout);
-      text = data?.result ?? data?.text ?? '';
-      usage = data?.usage;
-      if (!text) throw new Error('parsed JSON had no result/text field');
-    } catch {
-      const lastBrace = stdout.lastIndexOf('{');
-      if (lastBrace >= 0) {
-        try {
-          const data = JSON.parse(stdout.slice(lastBrace));
-          text = data?.result ?? data?.text ?? '';
-          usage = data?.usage;
-        } catch {
-          text = stdout.trim();
+      const finish = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearInterval(inactivityCheck);
+        clearTimeout(hardCeiling);
+        fn();
+        if (!child.killed) child.kill('SIGTERM');
+      };
+
+      const inactivityCheck = setInterval(() => {
+        const idleMs = Date.now() - lastActivity;
+        if (idleMs > inactivityTimeoutMs) {
+          log.warn(`[claude-cli] no output for ${Math.round(idleMs / 1000)}s — treating as stuck, killing.`);
+          finish(() => reject(new Error(
+            `Claude Code CLI: no output for ${Math.round(inactivityTimeoutMs / 1000)}s (likely stuck) ` +
+            `after ${Date.now() - startedAt}ms total.`
+          )));
         }
-      } else {
-        text = stdout.trim();
-      }
+      }, 5_000);
 
-      if (!text) {
-        throw new Error(
-          `Claude Code CLI output didn't match the expected JSON shape and had no ` +
-          `usable fallback text. CLI version: ${this.claudeCliVersion ?? 'unknown'}. ` +
-          `Raw output (truncated): ${stdout.slice(0, 300)}`
+      const hardCeiling = setTimeout(() => {
+        finish(() => reject(new Error(
+          `Claude Code CLI call exceeded the ${Math.round(maxTimeoutMs / 1000)}s hard ceiling — ` +
+          `still producing output, but this is taking unreasonably long.`
+        )));
+      }, maxTimeoutMs);
+
+      child.on('error', (err: any) => {
+        finish(() => {
+          if (err?.code === 'ENOENT') {
+            reject(new Error(`Claude Code CLI not found. Install it and run "claude login".`));
+          } else {
+            reject(new Error(`Claude Code CLI spawn error: ${err?.message || err}`));
+          }
+        });
+      });
+
+      child.stdout.on('data', (chunk: Buffer) => {
+        lastActivity = Date.now();
+        stdoutBuf += chunk.toString('utf-8');
+        let idx: number;
+        while ((idx = stdoutBuf.indexOf('\n')) >= 0) {
+          const line = stdoutBuf.slice(0, idx).trim();
+          stdoutBuf = stdoutBuf.slice(idx + 1);
+          if (!line) continue;
+          let evt: any;
+          try {
+            evt = JSON.parse(line);
+          } catch {
+            continue; // not every line is JSON we care about; skip silently
+          }
+          if (evt?.type !== 'result') continue;
+
+          const text = evt?.result ?? '';
+          log.info(
+            `[claude-cli] result event after ${Date.now() - startedAt}ms: ` +
+            `is_error=${evt?.is_error} subtype=${evt?.subtype} numTurns=${evt?.num_turns} chars=${text.length}` +
+            (evt?.is_error && !text ? ` (empty result on error — subtype is the only detail available)` : '')
+          );
+          finish(() => {
+            if (evt?.is_error) {
+              reject(new Error(`Claude Code CLI error: ${text || evt?.subtype || 'unknown error'}`));
+              return;
+            }
+            if (!text) {
+              reject(new Error(`Claude Code CLI returned an empty result.`));
+              return;
+            }
+            resolve({
+              text,
+              tokensUsed: (evt?.usage?.input_tokens ?? 0) + (evt?.usage?.output_tokens ?? 0),
+              // Rides the subscription — no separate metered cost to the
+              // user, even though the CLI's own JSON includes an internal
+              // total_cost_usd estimate.
+              estimatedCost: 0,
+              provider: provider.id, // 'claude-cli' or 'claude-cli-opus'
+            });
+          });
+        }
+      });
+
+      child.stderr.on('data', (chunk: Buffer) => {
+        lastActivity = Date.now();
+        stderrBuf += chunk.toString('utf-8');
+      });
+
+      // Only reached if the process exits WITHOUT us ever seeing a result
+      // event (crash, auth failure before any output, killed by something
+      // other than our own finish()) — the normal success/error paths above
+      // already resolved/rejected and killed the child themselves.
+      child.on('close', (code, signal) => {
+        if (settled) return;
+        settled = true;
+        clearInterval(inactivityCheck);
+        clearTimeout(hardCeiling);
+        log.warn(
+          `[claude-cli] exited (code=${code}, signal=${signal}) after ${Date.now() - startedAt}ms ` +
+          `without a result event. stderr="${stderrBuf.slice(0, 1500)}"`
         );
-      }
-    }
+        const stderrLower = stderrBuf.toLowerCase();
+        if (stderrLower.includes('not logged in') || stderrLower.includes('authentication')) {
+          reject(new Error(`Claude Code CLI is not authenticated. Run "claude logout" then "claude login" first.`));
+          return;
+        }
+        reject(new Error(
+          `Claude Code CLI exited (code=${code}, signal=${signal}) without producing a result. ` +
+          `stderr="${stderrBuf.slice(0, 500)}"`
+        ));
+      });
 
-    return {
-      text,
-      tokensUsed: (usage?.input_tokens ?? 0) + (usage?.output_tokens ?? 0),
-      // Rides the subscription — no separate metered cost to the user, even
-      // though the CLI's own JSON includes an internal total_cost_usd estimate.
-      estimatedCost: 0,
-      provider: provider.id, // 'claude-cli' or 'claude-cli-opus'
-    };
+      child.stdin!.end(prompt);
+    });
   }
 
   // ── OpenAI-compatible (OpenAI, DeepSeek) ──

--- a/gateway/src/ai/router.ts
+++ b/gateway/src/ai/router.ts
@@ -4,8 +4,12 @@
  * Optimized for writing tasks
  */
 
-import { createHash } from 'crypto';
-import { execFile, spawn } from 'node:child_process';
+import { createHash, randomUUID } from 'crypto';
+import { execFile, spawn as nodeSpawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, stat, unlink, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { Vault } from '../security/vault.js';
 import { CostTracker } from '../services/costs.js';
@@ -209,6 +213,15 @@ export const KNOWN_MODELS: Record<string, string[]> = {
  */
 const CLAUDE_CLI_PREMIUM_TASKS = new Set(['creative_writing', 'final_edit']);
 
+/** claude-cli and claude-cli-opus share ONE binary, ONE OAuth token, and ONE
+ *  rate limiter. Anywhere we pick a "different" provider as a fallback or
+ *  measure transport health, both ids must be treated as the same transport
+ *  — routing a failed claude-cli call to claude-cli-opus is not a fallback,
+ *  it's a retry of the same broken thing (confirmed in production logs: an
+ *  auth failure on claude-cli was immediately followed by the identical
+ *  auth failure on claude-cli-opus). */
+const CLAUDE_CLI_TRANSPORT_IDS = new Set(['claude-cli', 'claude-cli-opus']);
+
 // ═══════════════════════════════════════════════════════════
 // Claude Code CLI provider helpers
 // ═══════════════════════════════════════════════════════════
@@ -223,7 +236,7 @@ const CLAUDE_CLI_PREMIUM_TASKS = new Set(['creative_writing', 'final_edit']);
  * config/user.json — same pattern as ollama.endpoint), default 2.
  */
 class Semaphore {
-  private queue: Array<() => void> = [];
+  private queue: Array<{ resolve: () => void }> = [];
   private active = 0;
 
   constructor(private max: number) {}
@@ -237,9 +250,33 @@ class Semaphore {
     return `active=${this.active}/${this.max} queued=${this.queue.length}`;
   }
 
-  async run<T>(fn: () => Promise<T>): Promise<T> {
+  /**
+   * Runs `fn` once a slot is free. `queueTimeoutMs`, if given, bounds how
+   * long a caller will wait for a slot — previously this wait was unbounded
+   * and invisible (a burst of large background calls could starve an
+   * interactive chat message for minutes with no signal anything was
+   * wrong). A timed-out waiter is spliced out of the queue rather than
+   * quietly resolving into a slot nobody wants anymore.
+   */
+  async run<T>(fn: () => Promise<T>, opts?: { queueTimeoutMs?: number }): Promise<T> {
     if (this.active >= this.max) {
-      await new Promise<void>(resolve => this.queue.push(resolve));
+      await new Promise<void>((resolveWait, rejectWait) => {
+        const entry: { resolve: () => void } = { resolve: resolveWait };
+        this.queue.push(entry);
+        if (opts?.queueTimeoutMs) {
+          const timer = setTimeout(() => {
+            const idx = this.queue.indexOf(entry);
+            if (idx >= 0) {
+              this.queue.splice(idx, 1);
+              rejectWait(new Error(
+                `Timed out after ${opts.queueTimeoutMs}ms waiting for a claude-cli slot ` +
+                `(queue depth was ${this.queue.length + 1}).`
+              ));
+            }
+          }, opts.queueTimeoutMs);
+          entry.resolve = () => { clearTimeout(timer); resolveWait(); };
+        }
+      });
     }
     this.active++;
     try {
@@ -247,10 +284,297 @@ class Semaphore {
     } finally {
       this.active--;
       const next = this.queue.shift();
-      if (next) next();
+      if (next) next.resolve();
     }
   }
 }
+
+/**
+ * Spaces out claude-cli spawns and backs off on failure. One AuthorAgent
+ * revision step can fire ~11 completion calls (primary + fallback +
+ * short-response retry + up to 6 word-count continuations + judge + quality
+ * retry) with zero spacing between them today. Living at the transport layer
+ * (rather than in step-executor's retry ladder) means every call site is
+ * protected without touching that code.
+ */
+class CliPacer {
+  private nextAllowedAt = 0;
+  private backoffMs = 0;
+
+  constructor(private minGapMs: number, private maxBackoffMs: number, private now: () => number = Date.now) {}
+
+  configure(minGapMs: number, maxBackoffMs: number): void {
+    this.minGapMs = minGapMs;
+    this.maxBackoffMs = maxBackoffMs;
+  }
+
+  async waitTurn(): Promise<void> {
+    const wait = this.nextAllowedAt - this.now();
+    if (wait > 0) await new Promise(r => setTimeout(r, wait));
+  }
+
+  recordSuccess(): void {
+    this.backoffMs = 0;
+    this.nextAllowedAt = this.now() + this.minGapMs;
+  }
+
+  recordFailure(): void {
+    this.backoffMs = Math.min(Math.max(2_000, this.backoffMs * 2), this.maxBackoffMs);
+    const jitter = this.backoffMs * (0.8 + Math.random() * 0.4); // ±20%
+    this.nextAllowedAt = this.now() + jitter;
+  }
+}
+
+/** Classification of a claude-cli failure, used to decide whether to open
+ *  the shared circuit breaker and how to pace retries. */
+export type CliFailureKind = 'auth' | 'quota' | 'transient' | 'fatal';
+
+export class ClaudeCliError extends Error {
+  constructor(message: string, public kind: CliFailureKind = 'transient', public retryAfterMs?: number) {
+    super(message);
+    this.name = 'ClaudeCliError';
+  }
+}
+
+const CLI_FATAL_PATTERNS = ['error_max_turns', 'system prompt file not found'];
+const CLI_AUTH_PATTERNS = [
+  'not logged in', 'authentication', 'oauth', 'invalid_grant',
+  'token has expired', 'claude login', 'unauthenticated', 're-authenticate',
+];
+const CLI_QUOTA_PATTERNS = ['usage limit', 'rate limit', '429', 'resets at', 'overloaded_error', 'credit balance'];
+
+/**
+ * Classify a claude-cli failure from whatever text we have (the result
+ * event's error text and/or buffered stderr). Fed from both the streaming
+ * result-event path and the process-exited-without-a-result path, so the
+ * two can't disagree about what kind of failure just happened.
+ *
+ * Important constraint (verified against the live CLI): `claude auth status`
+ * reports `loggedIn: true` even when a USAGE CAP is exhausted, not just when
+ * genuinely logged out. So an 'auth' classification can be cleared by a
+ * lazy re-probe of auth status; a 'quota' classification cannot — it only
+ * clears once its retry deadline passes.
+ */
+export function classifyClaudeCliFailure(input: { resultText?: string; stderr?: string }): {
+  kind: CliFailureKind;
+  message: string;
+  retryAfterMs?: number;
+} {
+  const hay = `${input.resultText || ''} ${input.stderr || ''}`.toLowerCase();
+
+  for (const p of CLI_FATAL_PATTERNS) {
+    if (hay.includes(p)) return { kind: 'fatal', message: input.resultText || input.stderr || p };
+  }
+  for (const p of CLI_AUTH_PATTERNS) {
+    if (hay.includes(p)) {
+      return {
+        kind: 'auth',
+        message: 'Claude Code CLI auth expired or revoked. Run: claude logout && claude login',
+      };
+    }
+  }
+  for (const p of CLI_QUOTA_PATTERNS) {
+    if (hay.includes(p)) {
+      const m = hay.match(/resets at ([^.,\n]+)/);
+      let retryAfterMs: number | undefined;
+      if (m) {
+        const parsed = Date.parse(m[1]);
+        if (!isNaN(parsed)) retryAfterMs = Math.max(60_000, parsed - Date.now());
+      }
+      return {
+        kind: 'quota',
+        message: `Claude Code usage limit reached.${m ? ` Resets at ${m[1].trim()}.` : ''}`,
+        retryAfterMs: retryAfterMs ?? 15 * 60_000,
+      };
+    }
+  }
+  return { kind: 'transient', message: input.resultText || input.stderr || 'unknown error' };
+}
+
+/** Parses a stream-json `result` event into either success text or an error. */
+export function parseClaudeCliResultEvent(
+  evt: any
+): { ok: true; text: string; tokensUsed: number } | { ok: false; error: string } {
+  const text = evt?.result ?? '';
+  if (evt?.is_error) {
+    return { ok: false, error: text || evt?.subtype || 'unknown error' };
+  }
+  if (!text) {
+    return { ok: false, error: 'Claude Code CLI returned an empty result.' };
+  }
+  return {
+    ok: true,
+    text,
+    tokensUsed: (evt?.usage?.input_tokens ?? 0) + (evt?.usage?.output_tokens ?? 0),
+  };
+}
+
+/** Incremental newline-delimited-JSON line splitter for a streamed stdout. */
+export function createNdjsonLineReader(onLine: (line: string) => void): { push(chunk: string): void } {
+  let buf = '';
+  return {
+    push(chunk: string) {
+      buf += chunk;
+      let idx: number;
+      while ((idx = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, idx).trim();
+        buf = buf.slice(idx + 1);
+        if (line) onLine(line);
+      }
+    },
+  };
+}
+
+/**
+ * How long to wait for the FIRST byte of output before treating a call as
+ * stuck. A trivial prompt needs only the base budget; AuthorAgent's largest
+ * prompts (up to ~600,000 chars for full-manuscript consistency checks) can
+ * legitimately take minutes just to upload and begin generating. Scaled
+ * linearly by prompt size, clamped to [base, ceiling].
+ */
+export function computeFirstTokenBudgetMs(promptChars: number, baseMs = 120_000, ceilingMs = 420_000): number {
+  const scaled = baseMs + promptChars * 0.3;
+  return Math.min(Math.max(scaled, baseMs), ceilingMs);
+}
+
+/**
+ * The CLI has no `--max-tokens` flag and applies no output cap of its own —
+ * so TASK_OUTPUT_BUDGET's per-task-type budgets (added specifically to fix
+ * truncated outlines/character-profiles on other providers) can't be
+ * enforced the same way here. What *is* worth preserving is the relative
+ * signal "this task wants a long answer" — appended to the system prompt we
+ * now fully control via --system-prompt-file. Only emitted for genuinely
+ * long-output tasks (maxTokens >= 8192) so short tasks aren't padded.
+ */
+export function deriveLengthDirective(maxTokens?: number): string {
+  if (!maxTokens || maxTokens < 8192) return '';
+  const words = Math.round(maxTokens * 0.75);
+  return (
+    `\n\n## Response length\n` +
+    `This task expects a substantial response (~${words} words). Do not truncate. ` +
+    `Produce the complete answer in a single response.\n`
+  );
+}
+
+const THINKING_TOKEN_BUDGETS: Record<'low' | 'medium' | 'high', number> = {
+  low: 1024,
+  medium: 4096,
+  high: 16384,
+};
+
+/** Maps AuthorAgent's abstract thinking level to the CLI's --max-thinking-tokens. */
+export function mapThinkingToMaxThinkingTokens(thinking?: 'low' | 'medium' | 'high'): number | undefined {
+  return thinking ? THINKING_TOKEN_BUDGETS[thinking] : undefined;
+}
+
+const SAFE_CLAUDE_CLI_MODEL_PATTERN = /^[A-Za-z0-9._:-]{1,64}$/;
+
+/** Defense-in-depth: the model string flows from user-editable config
+ *  (model-config.json via setProviderModel) into a spawned argv element. */
+export function isSafeClaudeCliModel(model: string): boolean {
+  return SAFE_CLAUDE_CLI_MODEL_PATTERN.test(model);
+}
+
+/**
+ * Exact argv for the hardened, NON-agentic invocation. Tools, skills,
+ * slash-commands, and MCP are all disabled — AuthorAgent already injects
+ * every piece of context (book bible, lessons, memory) directly into the
+ * prompt, so the model never needed Claude Code's own tool access. Verified
+ * empirically: dropping this scaffolding cuts ~28,800 tokens of dead weight
+ * per call (measured: 28,845 -> 383 context tokens for an identical trivial
+ * prompt; -> 139 with a neutral cwd, see resolveClaudeCliBin/CWD below).
+ *
+ * `--system-prompt-file` and `--max-turns` are real flags but UNDOCUMENTED —
+ * absent from `claude --help`, confirmed only in the binary's own strings.
+ * The CLI silently ignores unknown options with no error at all (verified:
+ * `claude -p --definitely-not-a-flag` produces zero complaint), so a future
+ * release renaming either flag would make AuthorAgent send NONE of the
+ * soul/book-bible/voice-profile context with no error — see
+ * verifyClaudeCliHardening() for the startup canary that guards against
+ * exactly this.
+ *
+ * `--tools` is a VARIADIC option — it must never be placed last, or it will
+ * greedily swallow whatever argv element follows it.
+ */
+export function buildClaudeCliArgs(o: {
+  model: string;
+  systemPromptFile: string;
+  maxTurns?: number;
+  maxThinkingTokens?: number;
+}): string[] {
+  const args = [
+    '-p',
+    '--output-format', 'stream-json',
+    '--verbose',
+    '--include-partial-messages',
+    '--model', o.model,
+    '--system-prompt-file', o.systemPromptFile,
+    '--tools', '',
+    '--disable-slash-commands',
+    '--strict-mcp-config',
+    '--setting-sources', '',
+    '--no-session-persistence',
+    '--max-turns', String(o.maxTurns ?? 1),
+  ];
+  if (o.maxThinkingTokens) {
+    args.push('--max-thinking-tokens', String(o.maxThinkingTokens));
+  }
+  return args;
+}
+
+/** Env vars that must NEVER reach the claude-cli child. This repo ships
+ *  .env.example and depends on dotenv — if an Anthropic API key or another
+ *  provider's credentials leak into the child's environment, Claude Code
+ *  prefers the key over OAuth and silently switches the user off their
+ *  subscription onto metered per-token billing, which is exactly what was
+ *  declined when choosing this provider. Matched by prefix so this stays
+ *  effective even as new *_API_KEY-shaped vars are added elsewhere. */
+const CLAUDE_CLI_ENV_DENYLIST_PREFIXES = [
+  'ANTHROPIC_', 'CLAUDE_CODE_USE_', 'AWS_', 'GOOGLE_', 'GEMINI_', 'OPENAI_',
+  'DEEPSEEK_', 'OPENROUTER_', 'AUTHORCLAW_',
+];
+
+/** Env vars the OS/OAuth login genuinely depends on. OAuth credentials for
+ *  the `claude.ai` login are resolved relative to the user's profile, so
+ *  stripping these would break authentication, not just "clean up" the env. */
+const CLAUDE_CLI_ENV_ALLOWLIST = [
+  'PATH', 'Path', 'SystemRoot', 'windir', 'ComSpec', 'TEMP', 'TMP',
+  'USERPROFILE', 'HOME', 'HOMEDRIVE', 'HOMEPATH', 'APPDATA', 'LOCALAPPDATA',
+  'PATHEXT', 'NUMBER_OF_PROCESSORS', 'PROCESSOR_ARCHITECTURE', 'OS',
+  'LANG', 'LC_ALL', 'USERNAME', 'COMPUTERNAME',
+];
+
+/**
+ * Builds a sanitized environment for the claude-cli child: an explicit
+ * allowlist of what the OS and OAuth login need, then a denylist pass over
+ * whatever made it through (belt-and-braces against a name collision).
+ */
+export function buildClaudeCliEnv(parentEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of CLAUDE_CLI_ENV_ALLOWLIST) {
+    const v = parentEnv[key];
+    if (v !== undefined) env[key] = v;
+  }
+  for (const key of Object.keys(env)) {
+    if (CLAUDE_CLI_ENV_DENYLIST_PREFIXES.some(p => key.toUpperCase().startsWith(p))) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
+/** Dedicated scratch space, entirely outside the workspace directory. The
+ *  workspace is a user document tree — often OneDrive/Dropbox-synced on
+ *  Windows — and these temp files hold the author's unpublished manuscript
+ *  text (soul + book bible + memory), so they don't belong there. */
+const CLAUDE_CLI_SCRATCH_DIR = join(tmpdir(), 'authoragent-claude-cli');
+/** Empty, dedicated cwd for the child. Claude Code auto-discovers CLAUDE.md
+ *  and project context from its working directory — an empty dir means
+ *  there's nothing to discover regardless of whether --setting-sources ""
+ *  behaves as documented, and it can't wander into AuthorAgent's own source
+ *  tree the way it did when the child inherited the gateway's cwd (this was
+ *  the actual mechanism behind the error_max_turns failures). */
+const CLAUDE_CLI_CWD_DIR = join(CLAUDE_CLI_SCRATCH_DIR, 'cwd');
 
 /**
  * The CLI's `--output-format json` shape isn't a versioned public contract —
@@ -308,8 +632,39 @@ export class AIRouter {
   // again in initialize() in case config was reloaded/reinitialized.
   private claudeCliSemaphore = new Semaphore(2);
   private claudeCliVersion: string | null = null;
+  private claudeCliBinCache: { bin: string } | null = null;
+  // Spacing/backoff between spawns — see CliPacer. Configured in initialize().
+  private claudeCliPacer = new CliPacer(1_500, 120_000, () => this.now());
+  // claude-cli and claude-cli-opus share one binary/token/rate-limiter — this
+  // is the shared health state both providers are gated on. 'auth' failures
+  // clear only via a successful lazy re-probe; 'quota' failures clear only
+  // once reopenAt passes (claude auth status reports loggedIn:true even
+  // while a usage cap is exhausted, so it cannot be used to clear a quota
+  // circuit — see classifyClaudeCliFailure).
+  private cliHealth: {
+    state: 'closed' | 'open';
+    reason: 'auth' | 'quota' | '';
+    message: string;
+    reopenAt: number;
+    lastProbeAt: number;
+  } = { state: 'closed', reason: '', message: '', reopenAt: 0, lastProbeAt: 0 };
 
-  constructor(config: any, vault: Vault, costs: CostTracker, workspaceDir?: string) {
+  // Injectable for tests (default: real Node implementations). Not exposed
+  // outside the constructor — production code always uses the defaults.
+  // execFile is deliberately NOT injected: checkClaudeCLI()'s two calls are
+  // simple, already-covered probes; spawn/now are what the streaming
+  // rewrite and its timeout logic actually need to be deterministically
+  // testable.
+  private spawnFn: typeof nodeSpawn;
+  private now: () => number;
+
+  constructor(
+    config: any,
+    vault: Vault,
+    costs: CostTracker,
+    workspaceDir?: string,
+    deps?: { spawn?: typeof nodeSpawn; now?: () => number }
+  ) {
     this.config = config;
     this.vault = vault;
     this.costs = costs;
@@ -320,6 +675,8 @@ export class AIRouter {
       this.modelConfig = new ModelConfig(workspaceDir);
     }
     this.claudeCliSemaphore.setMax(this.config?.['claude-cli']?.maxConcurrent ?? 2);
+    this.spawnFn = deps?.spawn ?? nodeSpawn;
+    this.now = deps?.now ?? Date.now;
   }
 
   /**
@@ -510,6 +867,11 @@ export class AIRouter {
       // Re-read maxConcurrent in case config changed since construction
       // (reinitialize() runs this again without recreating the router).
       this.claudeCliSemaphore.setMax(this.config['claude-cli']?.maxConcurrent ?? 2);
+      this.claudeCliPacer.configure(
+        this.config['claude-cli']?.minSpawnGapMs ?? 1_500,
+        this.config['claude-cli']?.maxBackoffMs ?? 120_000
+      );
+      await this.ensureClaudeCliScratchDirs();
 
       const probe = await this.checkClaudeCLI();
       if (probe.available) {
@@ -541,6 +903,12 @@ export class AIRouter {
           costPer1kInput: 0,
           costPer1kOutput: 0,
         });
+
+        // Fire-and-forget: don't delay startup on this, but do log its
+        // outcome. See verifyClaudeCliHardening's doc comment for why this
+        // exists — the CLI silently ignores unknown flags, so this is the
+        // only way to catch a future release quietly breaking the hardening.
+        this.verifyClaudeCliHardening().catch(() => {});
       } else {
         log.warn(`claude-cli unavailable: ${probe.reason}`);
       }
@@ -590,6 +958,226 @@ export class AIRouter {
     }
 
     return { available: true, version };
+  }
+
+  /**
+   * Create the claude-cli scratch directories if missing, and sweep any
+   * leftover temp system-prompt files older than an hour (crash residue
+   * from a prior run — normal cleanup is try/finally per call, this is only
+   * the backstop for when that couldn't run).
+   */
+  private async ensureClaudeCliScratchDirs(): Promise<void> {
+    try {
+      await mkdir(CLAUDE_CLI_SCRATCH_DIR, { recursive: true });
+      await mkdir(CLAUDE_CLI_CWD_DIR, { recursive: true });
+      const entries = await readdir(CLAUDE_CLI_SCRATCH_DIR).catch(() => [] as string[]);
+      const cutoff = Date.now() - 60 * 60 * 1000;
+      for (const name of entries) {
+        if (name === 'cwd') continue;
+        const p = join(CLAUDE_CLI_SCRATCH_DIR, name);
+        try {
+          const s = await stat(p);
+          if (s.isFile() && s.mtimeMs < cutoff) await unlink(p).catch(() => {});
+        } catch {
+          // Gone already, or not a file we can stat — ignore either way.
+        }
+      }
+    } catch (err: any) {
+      log.warn(`[claude-cli] could not prepare scratch dir ${CLAUDE_CLI_SCRATCH_DIR}: ${err?.message || err}`);
+    }
+  }
+
+  /**
+   * Resolve the real claude CLI binary, preferring a native install over any
+   * shim. On this platform, `spawn('claude')` resolves via PATH to whichever
+   * comes first — often a package-manager SHIM (e.g. a chocolatey wrapper)
+   * that launches the real, much larger binary as its OWN child process.
+   * Killing the shim (our normal cleanup — see the #25629 workaround in
+   * runClaudeCliOnce) does not kill that grandchild: it keeps running,
+   * holds the temp system-prompt file open, and keeps consuming
+   * subscription quota. This was firing on every successful call. Cached
+   * after the first resolution since it can't change during a process's
+   * lifetime.
+   */
+  private async resolveClaudeCliBin(): Promise<{ bin: string }> {
+    if (this.claudeCliBinCache) return this.claudeCliBinCache;
+
+    const configured = this.config?.['claude-cli']?.binPath;
+    if (configured && existsSync(configured)) {
+      this.claudeCliBinCache = { bin: configured };
+      return this.claudeCliBinCache;
+    }
+    if (process.platform === 'win32') {
+      const nativeCandidate = join(homedir(), '.local', 'bin', 'claude.exe');
+      if (existsSync(nativeCandidate)) {
+        this.claudeCliBinCache = { bin: nativeCandidate };
+        return this.claudeCliBinCache;
+      }
+    }
+    // Fall back to ordinary PATH resolution (unchanged behavior). If this
+    // resolves to a wrapper/shim, config.ai['claude-cli'].binPath is the
+    // escape hatch to point at the real binary explicitly.
+    this.claudeCliBinCache = { bin: 'claude' };
+    return this.claudeCliBinCache;
+  }
+
+  /**
+   * Kill a claude-cli child, and on Windows kill its whole process tree —
+   * plain SIGTERM only terminates the immediate process, not a grandchild
+   * launched by a shim (see resolveClaudeCliBin). Fire-and-forget: this
+   * runs during cleanup, after the call has already resolved or rejected,
+   * so a failure here must never surface as a call failure.
+   */
+  private killClaudeCliProcess(child: import('node:child_process').ChildProcess): void {
+    if (child.killed || child.exitCode !== null) return;
+    if (process.platform === 'win32' && child.pid) {
+      execFile('taskkill', ['/PID', String(child.pid), '/T', '/F'], () => { /* best-effort */ });
+    } else {
+      child.kill('SIGTERM');
+    }
+  }
+
+  /** Writes the system prompt to a unique scratch file for --system-prompt-file.
+   *  Mode 0o600, never logged (only its length is — see runClaudeCliOnce). */
+  private async writeSystemPromptFile(content: string): Promise<string> {
+    const path = join(CLAUDE_CLI_SCRATCH_DIR, `${process.pid}-${Date.now()}-${randomUUID()}.txt`);
+    await writeFile(path, content, { encoding: 'utf8', mode: 0o600 });
+    return path;
+  }
+
+  /**
+   * Removes a temp system-prompt file, retrying briefly since on Windows an
+   * unlink of a file the (just-killed) child still has open can fail with
+   * EBUSY/EPERM rather than deferring like POSIX would. Never throws —
+   * cleanup failure must not fail the call; ensureClaudeCliScratchDirs's
+   * hourly sweep is the backstop for anything that never gets removed.
+   */
+  private async removeSystemPromptFile(path: string): Promise<void> {
+    const delays = [50, 150, 400];
+    for (let i = 0; i <= delays.length; i++) {
+      try {
+        await unlink(path);
+        return;
+      } catch (err: any) {
+        if (err?.code === 'ENOENT') return;
+        if (i === delays.length) {
+          log.warn(`[claude-cli] could not remove temp system-prompt file (will be swept later): ${path}`);
+          return;
+        }
+        await new Promise(r => setTimeout(r, delays[i]));
+      }
+    }
+  }
+
+  /**
+   * Returns a rejection message if the shared claude-cli/claude-cli-opus
+   * circuit is open, or null if the call may proceed. Checked BEFORE
+   * spawning — a known-broken transport should fail in milliseconds with an
+   * actionable message, not after a multi-minute timeout.
+   */
+  private checkClaudeCliCircuit(): string | null {
+    const h = this.cliHealth;
+    if (h.state === 'closed') return null;
+
+    const now = this.now();
+    if (h.reason === 'quota') {
+      if (now >= h.reopenAt) {
+        this.closeClaudeCliCircuit();
+        return null;
+      }
+      const mins = Math.ceil((h.reopenAt - now) / 60_000);
+      return `${h.message} (retry in ~${mins} min)`;
+    }
+
+    // auth: only a successful re-probe can clear this. Rate-limited to once
+    // a minute so a retry storm can't turn into a probe storm — and note a
+    // usage-cap exhaustion still reports loggedIn:true, so this path is
+    // only ever entered for genuine auth failures, never quota ones.
+    if (now - h.lastProbeAt > 60_000) {
+      h.lastProbeAt = now;
+      this.checkClaudeCLI()
+        .then(probe => {
+          if (probe.available) {
+            this.closeClaudeCliCircuit();
+            const cli = this.providers.get('claude-cli');
+            const opus = this.providers.get('claude-cli-opus');
+            if (cli) cli.available = true;
+            if (opus) opus.available = true;
+            log.info('[claude-cli] auth circuit cleared by lazy re-probe.');
+          }
+        })
+        .catch(() => { /* stays open; next call retries the probe after the cooldown */ });
+    }
+    return h.message;
+  }
+
+  private openClaudeCliCircuit(reason: 'auth' | 'quota', message: string, retryAfterMs?: number): void {
+    const alreadyOpenSameReason = this.cliHealth.state === 'open' && this.cliHealth.reason === reason;
+    this.cliHealth = {
+      state: 'open',
+      reason,
+      message,
+      reopenAt: reason === 'quota' ? this.now() + (retryAfterMs ?? 15 * 60_000) : 0,
+      lastProbeAt: this.cliHealth.lastProbeAt,
+    };
+    if (reason === 'auth') {
+      const cli = this.providers.get('claude-cli');
+      const opus = this.providers.get('claude-cli-opus');
+      if (cli) cli.available = false;
+      if (opus) opus.available = false;
+    }
+    if (!alreadyOpenSameReason) {
+      log.warn(`[claude-cli] circuit OPEN (${reason}): ${message}`);
+    }
+  }
+
+  private closeClaudeCliCircuit(): void {
+    if (this.cliHealth.state === 'closed') return;
+    log.info(`[claude-cli] circuit CLOSED (was: ${this.cliHealth.reason})`);
+    this.cliHealth = { state: 'closed', reason: '', message: '', reopenAt: 0, lastProbeAt: this.cliHealth.lastProbeAt };
+  }
+
+  /**
+   * Startup canary — the mitigation for the CLI's silent-unknown-flag
+   * behavior. Runs one hardened call with a nonce embedded in the
+   * system-prompt file and asserts the reply contains it, which is the only
+   * way to actually prove --system-prompt-file is honored rather than
+   * silently ignored. Also warns (does not fail) if input_tokens comes back
+   * suspiciously high, which would mean the scaffolding-stripping flags
+   * (--tools "", --strict-mcp-config, etc.) stopped taking effect. Never
+   * takes the provider offline on a miss — a false-negative canary
+   * shouldn't remove the user's only configured transport.
+   */
+  private async verifyClaudeCliHardening(): Promise<void> {
+    if (this.config?.['claude-cli']?.canary === false) return;
+    const nonce = randomUUID().slice(0, 8);
+    try {
+      const result = await this.runClaudeCliOnce(
+        { id: 'claude-cli', name: 'canary', model: 'sonnet', tier: 'free', available: true, endpoint: 'local-cli', maxTokens: 100, costPer1kInput: 0, costPer1kOutput: 0 },
+        {
+          provider: 'claude-cli',
+          system: `You are a test harness. Reply with exactly: OK-${nonce}`,
+          messages: [{ role: 'user', content: 'ping' }],
+        },
+        this.now()
+      );
+      if (!result.text.includes(nonce)) {
+        log.warn(
+          `[claude-cli] startup canary: reply did not contain the expected nonce — ` +
+          `--system-prompt-file may not be honored by this CLI version. Reply: "${result.text.slice(0, 200)}"`
+        );
+      } else if (result.tokensUsed > 3_000) {
+        log.warn(
+          `[claude-cli] startup canary: input+output tokens=${result.tokensUsed}, expected well under 1,000. ` +
+          `The hardening flags (--tools "", --strict-mcp-config, etc.) may no longer be taking effect — ` +
+          `a CLI update may have changed flag names or behavior.`
+        );
+      } else {
+        log.info(`[claude-cli] startup canary passed (${result.tokensUsed} tokens).`);
+      }
+    } catch (err: any) {
+      log.warn(`[claude-cli] startup canary failed to run: ${err?.message || err}`);
+    }
   }
 
   /**
@@ -793,10 +1381,21 @@ export class AIRouter {
    * preferring free providers (Ollama, Gemini free tier) instead.
    */
   getFallbackProvider(currentId: string): AIProvider | null {
+    // claude-cli and claude-cli-opus are the SAME transport (one binary, one
+    // OAuth token, one rate limiter). A failed claude-cli call falling back
+    // to claude-cli-opus isn't a fallback, it's a retry of the same broken
+    // thing — confirmed in production: an auth failure on claude-cli was
+    // immediately followed by the identical auth failure on claude-cli-opus,
+    // doubling load on an already-unhealthy transport. Treat both ids as
+    // "current" so neither can be selected as the other's fallback.
+    const sameTransport = CLAUDE_CLI_TRANSPORT_IDS.has(currentId)
+      ? CLAUDE_CLI_TRANSPORT_IDS
+      : new Set([currentId]);
+
     // Explicit preferred fallback takes priority over the generic free/paid
     // heuristic below — e.g. "openai's live call just failed, go straight to
     // claude-cli" instead of whatever happens to be first by insertion order.
-    if (this.globalPreferredProviderFallback && this.globalPreferredProviderFallback !== currentId) {
+    if (this.globalPreferredProviderFallback && !sameTransport.has(this.globalPreferredProviderFallback)) {
       const configured = this.providers.get(this.globalPreferredProviderFallback);
       if (configured?.available) {
         return configured;
@@ -808,7 +1407,7 @@ export class AIRouter {
     const freeProviders: AIProvider[] = [];
     const paidProviders: AIProvider[] = [];
     for (const [id, provider] of this.providers) {
-      if (id === currentId || !provider.available) continue;
+      if (sameTransport.has(id) || !provider.available) continue;
       if (provider.tier === 'free') freeProviders.push(provider);
       else paidProviders.push(provider);
     }
@@ -1087,162 +1686,178 @@ export class AIRouter {
   //
   // CAVEATS:
   //  - Claude Code's rate limits/usage caps are tuned for interactive coding
-  //    sessions, not a pipeline firing 20-30 chapter-length calls per book.
-  //    Keep maxConcurrent low (config.ai['claude-cli'].maxConcurrent) and
-  //    expect throttling on long "Full Book" runs.
+  //    sessions, not a pipeline firing hundreds of calls per book. Keep
+  //    maxConcurrent low (config.ai['claude-cli'].maxConcurrent) — the
+  //    CliPacer below adds spacing/backoff on top of that, and the shared
+  //    circuit breaker fails fast instead of retrying into a known-broken
+  //    transport.
   //  - Single-shot only: `claude -p` isn't a multi-turn chat API, so the
   //    message history below is flattened into one prompt.
-  //  - No thinking-budget passthrough — Claude Code manages its own
-  //    reasoning internally; request.thinking is accepted but ignored here.
+  //  - This is a NON-agentic invocation: --tools "" disables all tool
+  //    access, so AuthorAgent's own context injection is the only context
+  //    the model gets. That's deliberate — see buildClaudeCliArgs's doc
+  //    comment for why (75x-207x fewer tokens per call than an agentic
+  //    invocation, measured).
   private async completeClaudeCode(
     provider: AIProvider,
     request: CompletionRequest
   ): Promise<CompletionResponse> {
-    return this.claudeCliSemaphore.run(() => this.runClaudeCliOnce(provider, request));
+    const circuitMessage = this.checkClaudeCliCircuit();
+    if (circuitMessage) {
+      throw new ClaudeCliError(`Claude Code CLI unavailable: ${circuitMessage}`, this.cliHealth.reason || 'transient');
+    }
+
+    const enqueuedAt = this.now();
+    await this.claudeCliPacer.waitTurn();
+
+    try {
+      const queueTimeoutMs = this.config?.['claude-cli']?.queueWaitTimeoutMs ?? 600_000;
+      const result = await this.claudeCliSemaphore.run(
+        () => this.runClaudeCliOnce(provider, request, enqueuedAt),
+        { queueTimeoutMs }
+      );
+      this.claudeCliPacer.recordSuccess();
+      return result;
+    } catch (err: any) {
+      const kind: CliFailureKind = err instanceof ClaudeCliError ? err.kind : 'transient';
+      if (kind === 'auth') {
+        this.openClaudeCliCircuit('auth', err.message);
+      } else if (kind === 'quota') {
+        this.openClaudeCliCircuit('quota', err.message, err.retryAfterMs);
+        this.claudeCliPacer.recordFailure();
+      } else {
+        this.claudeCliPacer.recordFailure();
+      }
+      throw err;
+    }
   }
 
   /**
-   * Runs `claude -p` in STREAMING mode and times it out on INACTIVITY, not
-   * total duration.
+   * Runs one hardened `claude -p` invocation in STREAMING mode, timing out
+   * on INACTIVITY rather than total duration.
    *
-   * Why: output-heavy tasks (full chapter drafts, 20-30 chapter outlines —
-   * up to TASK_OUTPUT_BUDGET's 16384 tokens) can legitimately take 5-10+
-   * minutes of steady token production through the CLI wrapper. A flat
-   * overall-duration timeout (previously 120s, then 300s) can't distinguish
-   * "still working, just slow" from "genuinely stuck" — it just kills
-   * whichever one happens to still be running when the clock runs out.
-   * Measured in production: one 24K-char-prompt call legitimately took
-   * 296.7s (just under the old 300s cap); a 20K-char-prompt call was killed
-   * at exactly 300s while (per this same logging) still producing output.
+   * Why streaming: output-heavy tasks (full chapter drafts, 20-30 chapter
+   * outlines) can legitimately take 5-10+ minutes of steady token
+   * production. A flat overall-duration timeout can't distinguish "still
+   * working, just slow" from "genuinely stuck" — it just kills whichever
+   * one happens to still be running when the clock runs out. This is a real
+   * regression that shipped once already: `--output-format stream-json`
+   * WITHOUT `--include-partial-messages` does not stream tokens at all — it
+   * emits one JSON object per COMPLETE message (init, then total silence
+   * for the entire generation, then the assistant message, then result). An
+   * inactivity timer built on that alone is a total-duration timeout in
+   * disguise. `--include-partial-messages` is what makes stdout activity a
+   * real proxy for "is it still working."
    *
-   * The fix: `--output-format stream-json` emits one JSON object per line as
-   * the response is generated. We track the last time ANY data arrived and
-   * only kill the process if that goes quiet for `inactivityTimeoutMs` —
-   * so a slow-but-steady multi-minute generation is never killed early, but
-   * a genuine hang (no bytes at all) is caught quickly. `maxTimeoutMs` is a
-   * separate, generous absolute backstop against a truly runaway call.
-   *
-   * We also do NOT wait for the child process to exit naturally: resolve as
-   * soon as the `{"type":"result",...}` event is seen, then kill the
-   * process ourselves. This works around a confirmed upstream bug
+   * We do NOT wait for the child process to exit naturally: resolve as soon
+   * as the `{"type":"result",...}` event is seen, then kill the process
+   * ourselves. This works around a confirmed upstream bug
    * (anthropics/claude-code#25629) where stream-json mode can hang
    * indefinitely *after* emitting the result event instead of exiting.
+   *
+   * `enqueuedAt` (timestamp from before the semaphore was acquired) lets us
+   * log actual queue-wait time — previously invisible, now the first thing
+   * in the spawn log line.
    */
   private async runClaudeCliOnce(
     provider: AIProvider,
-    request: CompletionRequest
+    request: CompletionRequest,
+    enqueuedAt: number
   ): Promise<CompletionResponse> {
+    if (!isSafeClaudeCliModel(provider.model)) {
+      throw new ClaudeCliError(
+        `Refusing to spawn claude-cli with a suspicious model value: "${provider.model}".`,
+        'fatal'
+      );
+    }
+
     const transcript = request.messages
       .map(m => `${m.role === 'assistant' ? 'Assistant' : 'User'}: ${m.content}`)
       .join('\n\n');
-    const prompt = `${request.system}\n\n${transcript}`;
 
-    const inactivityTimeoutMs = this.config?.['claude-cli']?.inactivityTimeoutMs ?? 90_000;
-    const maxTimeoutMs = this.config?.['claude-cli']?.maxTimeoutMs ?? 900_000;
+    const lengthDirective = deriveLengthDirective(request.maxTokens);
+    const systemPromptContent = lengthDirective ? `${request.system}${lengthDirective}` : request.system;
+    const maxThinkingTokens = mapThinkingToMaxThinkingTokens(request.thinking);
 
-    const startedAt = Date.now();
+    const cfg = this.config?.['claude-cli'] ?? {};
+    const firstTokenBaseMs: number = cfg.firstTokenTimeoutMs ?? 120_000;
+    const firstTokenCeilingMs: number = cfg.firstTokenCeilingMs ?? 420_000;
+    const inactivityTimeoutMs: number = cfg.inactivityTimeoutMs ?? 60_000;
+    const maxTimeoutMs: number = cfg.maxTimeoutMs ?? 900_000;
+    const totalChars = systemPromptContent.length + transcript.length;
+    const firstTokenBudgetMs = computeFirstTokenBudgetMs(totalChars, firstTokenBaseMs, firstTokenCeilingMs);
+
+    const queueWaitMs = this.now() - enqueuedAt;
+    const startedAt = this.now();
+
+    const { bin } = await this.resolveClaudeCliBin();
+    const args = buildClaudeCliArgs({
+      model: provider.model,
+      systemPromptFile: '', // placeholder — filled in below once the file exists
+      maxTurns: 1,
+      maxThinkingTokens,
+    });
+
+    const systemPromptFile = await this.writeSystemPromptFile(systemPromptContent);
+    // Patch the real path into argv now that the file exists (buildClaudeCliArgs
+    // is a pure function and can't await the write itself).
+    const systemPromptFileIdx = args.indexOf('--system-prompt-file') + 1;
+    args[systemPromptFileIdx] = systemPromptFile;
+
     log.info(
-      `[claude-cli] spawning: model=${provider.model} promptChars=${prompt.length} ` +
-      `inactivityTimeoutMs=${inactivityTimeoutMs} maxTimeoutMs=${maxTimeoutMs} ` +
-      `activeSemaphoreSlots=${this.claudeCliSemaphore.debugState()}`
+      `[claude-cli] spawning: model=${provider.model} promptChars=${transcript.length} ` +
+      `systemChars=${systemPromptContent.length} queueWaitMs=${queueWaitMs} ` +
+      `firstTokenBudgetMs=${Math.round(firstTokenBudgetMs)} inactivityTimeoutMs=${inactivityTimeoutMs} ` +
+      `maxTimeoutMs=${maxTimeoutMs} activeSemaphoreSlots=${this.claudeCliSemaphore.debugState()}`
     );
 
-    return new Promise<CompletionResponse>((resolve, reject) => {
-      // spawn (not execFile) — no shell interpolation, same as before. We
-      // need direct stream access here rather than a promise-on-exit, so we
-      // can react to data as it arrives instead of waiting for the process
-      // to finish (which, per the bug above, may never happen naturally).
-      //
-      // --max-turns: generous, not 1. AuthorAgent's system prompt has the
-      // model check Book Bible / style guide / voice profile / outline
-      // before writing (write skill) — each of those can be a tool call,
-      // consuming a "turn" before the actual text response. A cap of 1
-      // aborted those with subtype "error_max_turns" and an empty result
-      // (caught live: audit log showed exactly this). 12 leaves comfortable
-      // room for that context-gathering while still bounding a genuinely
-      // runaway agentic loop.
-      const child = spawn(
-        'claude',
-        ['-p', '--output-format', 'stream-json', '--verbose', '--max-turns', '12', '--model', provider.model],
-        { stdio: ['pipe', 'pipe', 'pipe'] }
-      );
-
-      let stdoutBuf = '';
-      let stderrBuf = '';
-      let settled = false;
-      let lastActivity = Date.now();
-
-      const finish = (fn: () => void) => {
-        if (settled) return;
-        settled = true;
-        clearInterval(inactivityCheck);
-        clearTimeout(hardCeiling);
-        fn();
-        if (!child.killed) child.kill('SIGTERM');
-      };
-
-      const inactivityCheck = setInterval(() => {
-        const idleMs = Date.now() - lastActivity;
-        if (idleMs > inactivityTimeoutMs) {
-          log.warn(`[claude-cli] no output for ${Math.round(idleMs / 1000)}s — treating as stuck, killing.`);
-          finish(() => reject(new Error(
-            `Claude Code CLI: no output for ${Math.round(inactivityTimeoutMs / 1000)}s (likely stuck) ` +
-            `after ${Date.now() - startedAt}ms total.`
-          )));
-        }
-      }, 5_000);
-
-      const hardCeiling = setTimeout(() => {
-        finish(() => reject(new Error(
-          `Claude Code CLI call exceeded the ${Math.round(maxTimeoutMs / 1000)}s hard ceiling — ` +
-          `still producing output, but this is taking unreasonably long.`
-        )));
-      }, maxTimeoutMs);
-
-      child.on('error', (err: any) => {
-        finish(() => {
-          if (err?.code === 'ENOENT') {
-            reject(new Error(`Claude Code CLI not found. Install it and run "claude login".`));
-          } else {
-            reject(new Error(`Claude Code CLI spawn error: ${err?.message || err}`));
-          }
+    try {
+      return await new Promise<CompletionResponse>((resolve, reject) => {
+        const child = this.spawnFn(bin, args, {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          cwd: CLAUDE_CLI_CWD_DIR,
+          env: buildClaudeCliEnv(process.env),
         });
-      });
 
-      child.stdout.on('data', (chunk: Buffer) => {
-        lastActivity = Date.now();
-        stdoutBuf += chunk.toString('utf-8');
-        let idx: number;
-        while ((idx = stdoutBuf.indexOf('\n')) >= 0) {
-          const line = stdoutBuf.slice(0, idx).trim();
-          stdoutBuf = stdoutBuf.slice(idx + 1);
-          if (!line) continue;
+        let stderrBuf = '';
+        let settled = false;
+        let sawFirstByte = false;
+        let lastStdoutActivity = this.now();
+
+        const finish = (fn: () => void) => {
+          if (settled) return;
+          settled = true;
+          clearInterval(watchdog);
+          clearTimeout(hardCeiling);
+          fn();
+          this.killClaudeCliProcess(child);
+        };
+
+        const reader = createNdjsonLineReader((line) => {
           let evt: any;
           try {
             evt = JSON.parse(line);
           } catch {
-            continue; // not every line is JSON we care about; skip silently
+            return; // not every line is JSON we care about; skip silently
           }
-          if (evt?.type !== 'result') continue;
+          if (evt?.type !== 'result') return;
 
           const text = evt?.result ?? '';
           log.info(
-            `[claude-cli] result event after ${Date.now() - startedAt}ms: ` +
+            `[claude-cli] result event after ${this.now() - startedAt}ms: ` +
             `is_error=${evt?.is_error} subtype=${evt?.subtype} numTurns=${evt?.num_turns} chars=${text.length}` +
             (evt?.is_error && !text ? ` (empty result on error — subtype is the only detail available)` : '')
           );
+          const parsed = parseClaudeCliResultEvent(evt);
           finish(() => {
-            if (evt?.is_error) {
-              reject(new Error(`Claude Code CLI error: ${text || evt?.subtype || 'unknown error'}`));
-              return;
-            }
-            if (!text) {
-              reject(new Error(`Claude Code CLI returned an empty result.`));
+            if (!parsed.ok) {
+              const classified = classifyClaudeCliFailure({ resultText: parsed.error, stderr: stderrBuf });
+              reject(new ClaudeCliError(`Claude Code CLI error: ${parsed.error}`, classified.kind, classified.retryAfterMs));
               return;
             }
             resolve({
-              text,
-              tokensUsed: (evt?.usage?.input_tokens ?? 0) + (evt?.usage?.output_tokens ?? 0),
+              text: parsed.text,
+              tokensUsed: parsed.tokensUsed,
               // Rides the subscription — no separate metered cost to the
               // user, even though the CLI's own JSON includes an internal
               // total_cost_usd estimate.
@@ -1250,40 +1865,98 @@ export class AIRouter {
               provider: provider.id, // 'claude-cli' or 'claude-cli-opus'
             });
           });
-        }
-      });
+        });
 
-      child.stderr.on('data', (chunk: Buffer) => {
-        lastActivity = Date.now();
-        stderrBuf += chunk.toString('utf-8');
-      });
+        const watchdog = setInterval(() => {
+          const now = this.now();
+          if (!sawFirstByte) {
+            if (now - startedAt > firstTokenBudgetMs) {
+              finish(() => reject(new ClaudeCliError(
+                `Claude Code CLI: no output for ${Math.round((now - startedAt) / 1000)}s waiting for the ` +
+                `first response byte (budget ${Math.round(firstTokenBudgetMs / 1000)}s for a ${totalChars}-char prompt).`
+              )));
+            }
+            return;
+          }
+          if (now - lastStdoutActivity > inactivityTimeoutMs) {
+            log.warn(`[claude-cli] no stdout for ${Math.round((now - lastStdoutActivity) / 1000)}s mid-generation — treating as stuck, killing.`);
+            finish(() => reject(new ClaudeCliError(
+              `Claude Code CLI: no output for ${Math.round(inactivityTimeoutMs / 1000)}s mid-generation ` +
+              `(likely stuck) after ${now - startedAt}ms total.`
+            )));
+          }
+        }, 5_000);
 
-      // Only reached if the process exits WITHOUT us ever seeing a result
-      // event (crash, auth failure before any output, killed by something
-      // other than our own finish()) — the normal success/error paths above
-      // already resolved/rejected and killed the child themselves.
-      child.on('close', (code, signal) => {
-        if (settled) return;
-        settled = true;
-        clearInterval(inactivityCheck);
-        clearTimeout(hardCeiling);
-        log.warn(
-          `[claude-cli] exited (code=${code}, signal=${signal}) after ${Date.now() - startedAt}ms ` +
-          `without a result event. stderr="${stderrBuf.slice(0, 1500)}"`
-        );
-        const stderrLower = stderrBuf.toLowerCase();
-        if (stderrLower.includes('not logged in') || stderrLower.includes('authentication')) {
-          reject(new Error(`Claude Code CLI is not authenticated. Run "claude logout" then "claude login" first.`));
-          return;
-        }
-        reject(new Error(
-          `Claude Code CLI exited (code=${code}, signal=${signal}) without producing a result. ` +
-          `stderr="${stderrBuf.slice(0, 500)}"`
-        ));
-      });
+        const hardCeiling = setTimeout(() => {
+          finish(() => reject(new ClaudeCliError(
+            `Claude Code CLI call exceeded the ${Math.round(maxTimeoutMs / 1000)}s hard ceiling — ` +
+            `still producing output, but this is taking unreasonably long.`
+          )));
+        }, maxTimeoutMs);
 
-      child.stdin!.end(prompt);
-    });
+        child.on('error', (err: any) => {
+          finish(() => {
+            if (err?.code === 'ENOENT') {
+              reject(new ClaudeCliError(`Claude Code CLI not found. Install it and run "claude login".`, 'fatal'));
+            } else {
+              reject(new ClaudeCliError(`Claude Code CLI spawn error: ${err?.message || err}`));
+            }
+          });
+        });
+
+        // Guards against an unhandled EPIPE: a large prompt plus an early
+        // child exit (bad flag, crash before reading stdin) can fail the
+        // write after the OS pipe buffer fills. Without this listener, an
+        // 'error' event on the stdin stream throws and can crash the whole
+        // gateway process — the 'close'/result-event paths above already
+        // cover reporting the actual failure; this only stops the write
+        // itself from becoming an uncaught exception.
+        child.stdin!.on('error', (err: any) => {
+          log.warn(`[claude-cli] stdin write error (likely early child exit): ${err?.message || err}`);
+        });
+
+        child.stdout.on('data', (chunk: Buffer) => {
+          sawFirstByte = true;
+          lastStdoutActivity = this.now();
+          reader.push(chunk.toString('utf-8'));
+        });
+
+        child.stderr.on('data', (chunk: Buffer) => {
+          // Deliberately does NOT feed the watchdog. Chatty stderr was
+          // previously the ONLY thing keeping the (non-streaming) inactivity
+          // timer alive during long generations — accidental life support
+          // for a timer that was otherwise a total-duration timeout in
+          // disguise. Real progress is now measured on stdout only, which
+          // genuinely streams thanks to --include-partial-messages.
+          stderrBuf += chunk.toString('utf-8');
+        });
+
+        // Only reached if the process exits WITHOUT us ever seeing a result
+        // event (crash, auth failure before any output, killed by something
+        // other than our own finish()) — the normal success/error paths
+        // above already resolved/rejected and killed the child themselves.
+        child.on('close', (code, signal) => {
+          if (settled) return;
+          settled = true;
+          clearInterval(watchdog);
+          clearTimeout(hardCeiling);
+          log.warn(
+            `[claude-cli] exited (code=${code}, signal=${signal}) after ${this.now() - startedAt}ms ` +
+            `without a result event. stderr="${stderrBuf.slice(0, 1500)}"`
+          );
+          const classified = classifyClaudeCliFailure({ stderr: stderrBuf });
+          reject(new ClaudeCliError(
+            `Claude Code CLI exited (code=${code}, signal=${signal}) without producing a result. ${classified.message}`,
+            classified.kind,
+            classified.retryAfterMs
+          ));
+        });
+
+        child.stdin!.end(transcript);
+      });
+    } finally {
+      await this.removeSystemPromptFile(systemPromptFile);
+    }
   }
 
   // ── OpenAI-compatible (OpenAI, DeepSeek) ──

--- a/gateway/src/api/routes.ts
+++ b/gateway/src/api/routes.ts
@@ -47,6 +47,7 @@ import { registerWave3GatedRoutes } from './routes/wave3-gated.js';
 import { registerWebsiteRoutes } from './routes/website.js';
 import { registerReaderPanelRoutes } from './routes/reader-panel.js';
 import { registerReaderFeedbackRoutes } from './routes/reader-feedback.js';
+import { registerReviewRoutes } from './routes/review.js';
 
 export function createAPIRoutes(app: Application, gateway: any, rootDir?: string): void {
   const ctx = createApiContext(app, gateway, rootDir);
@@ -81,4 +82,5 @@ export function createAPIRoutes(app: Application, gateway: any, rootDir?: string
   registerWebsiteRoutes(ctx);
   registerReaderPanelRoutes(ctx);
   registerReaderFeedbackRoutes(ctx);
+  registerReviewRoutes(ctx);
 }

--- a/gateway/src/api/routes.ts
+++ b/gateway/src/api/routes.ts
@@ -24,6 +24,7 @@ import { registerSystemRoutes } from './routes/system.js';
 import { registerProjectRoutes } from './routes/projects.js';
 import { registerDocumentRoutes } from './routes/documents.js';
 import { registerContextHeartbeatRoutes } from './routes/context-heartbeat.js';
+import { registerBookBibleRoutes } from './routes/book-bible.js';
 import { registerAuthorOSToolsRoutes } from './routes/authoros-tools.js';
 import { registerPersonaRoutes } from './routes/personas.js';
 import { registerResearchWebRoutes } from './routes/research-web.js';
@@ -57,6 +58,7 @@ export function createAPIRoutes(app: Application, gateway: any, rootDir?: string
   registerProjectRoutes(ctx);
   registerDocumentRoutes(ctx);
   registerContextHeartbeatRoutes(ctx);
+  registerBookBibleRoutes(ctx);
   registerAuthorOSToolsRoutes(ctx);
   registerPersonaRoutes(ctx);
   registerResearchWebRoutes(ctx);

--- a/gateway/src/api/routes/book-bible.test.ts
+++ b/gateway/src/api/routes/book-bible.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Endpoint tests for POST/GET /api/projects/:id/book-bible.
+ * Spins up a real (ephemeral-port) Express app around registerBookBibleRoutes
+ * with a minimal fake project engine — same wiring shape as production
+ * (ContextEngine + MemoryService rooted under <root>/workspace, ApiContext
+ * baseDir = <root>), just in a tmp dir.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import type { Server } from 'http';
+import type { AddressInfo } from 'net';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { registerBookBibleRoutes } from './book-bible.js';
+import { ContextEngine } from '../../services/context-engine.js';
+import { MemoryService } from '../../services/memory.js';
+
+describe('book-bible routes', () => {
+  let rootDir: string;
+  let server: Server;
+  let baseUrl: string;
+  let projects: Map<string, any>;
+
+  beforeEach(async () => {
+    rootDir = mkdtempSync(join(tmpdir(), 'authoragent-book-bible-routes-'));
+    const workspaceDir = join(rootDir, 'workspace');
+    const contextEngine = new ContextEngine(workspaceDir);
+    const memory = new MemoryService(join(workspaceDir, 'memory'), {});
+    await memory.initialize();
+
+    projects = new Map();
+    projects.set('project-1', { id: 'project-1', title: 'Test Book', steps: [] });
+
+    const gateway = {
+      getProjectEngine: () => ({
+        getProject: (id: string) => projects.get(id),
+        listProjects: () => Array.from(projects.values()),
+      }),
+    };
+
+    const app = express();
+    app.use(express.json());
+    registerBookBibleRoutes({
+      app, gateway, services: { contextEngine, memory }, baseDir: rootDir,
+    } as any);
+
+    await new Promise<void>(resolve => {
+      server = app.listen(0, () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+    try { rmSync(rootDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('GET 404s before the bible has ever been compiled', async () => {
+    const res = await fetch(`${baseUrl}/api/projects/project-1/book-bible`);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/not been compiled/i);
+  });
+
+  it('GET 404s for an unknown project', async () => {
+    const res = await fetch(`${baseUrl}/api/projects/does-not-exist/book-bible`);
+    expect(res.status).toBe(404);
+  });
+
+  it('POST 404s for an unknown project', async () => {
+    const res = await fetch(`${baseUrl}/api/projects/does-not-exist/book-bible`, { method: 'POST' });
+    expect(res.status).toBe(404);
+  });
+
+  it('POST compiles and persists the bible; a subsequent GET returns the same content', async () => {
+    const postRes = await fetch(`${baseUrl}/api/projects/project-1/book-bible`, { method: 'POST' });
+    expect(postRes.status).toBe(200);
+    const postBody = await postRes.json();
+    expect(postBody.success).toBe(true);
+    expect(postBody.content).toContain('# Test Book — Book Bible');
+    expect(postBody.mergedProjectIds).toEqual(['project-1']);
+
+    const getRes = await fetch(`${baseUrl}/api/projects/project-1/book-bible`);
+    expect(getRes.status).toBe(200);
+    const getBody = await getRes.json();
+    expect(getBody.content).toBe(postBody.content);
+  });
+
+  it('POST regenerates on a second call (idempotent recompile)', async () => {
+    const first = await (await fetch(`${baseUrl}/api/projects/project-1/book-bible`, { method: 'POST' })).json();
+    const second = await (await fetch(`${baseUrl}/api/projects/project-1/book-bible`, { method: 'POST' })).json();
+    expect(second.success).toBe(true);
+    expect(second.content).toBe(first.content);
+  });
+});

--- a/gateway/src/api/routes/book-bible.ts
+++ b/gateway/src/api/routes/book-bible.ts
@@ -1,0 +1,57 @@
+/**
+ * book-bible routes — compile/fetch the canonical per-book book-bible.md.
+ * Structured like the existing /api/projects/:id/compile route in
+ * documents.ts: same project lookup, 404 handling, and baseDir usage.
+ */
+import { Request, Response } from 'express';
+import type { ApiContext } from '../context.js';
+import { BookBibleService } from '../../services/book-bible.js';
+
+export function registerBookBibleRoutes(ctx: ApiContext): void {
+  const { app, gateway, services, baseDir } = ctx;
+  const bookBible = new BookBibleService(baseDir);
+
+  // Compile (or regenerate) the book bible for a project.
+  app.post('/api/projects/:id/book-bible', async (req: Request, res: Response) => {
+    const engine = gateway.getProjectEngine?.();
+    if (!engine) return res.status(503).json({ error: 'Project engine not initialized' });
+    const project = engine.getProject(req.params.id);
+    if (!project) return res.status(404).json({ error: 'Project not found' });
+
+    const contextEngine = services.contextEngine;
+    if (!contextEngine) return res.status(503).json({ error: 'Context engine not available' });
+
+    try {
+      const projectId = String(req.params.id);
+      const result = await bookBible.compile(engine, contextEngine, projectId);
+      await services.memory.saveBookBibleEntry(projectId, 'book-bible.md', result.content);
+      res.json({
+        success: true,
+        content: result.content,
+        mergedProjectIds: result.mergedProjectIds,
+        counts: result.counts,
+      });
+    } catch (err: any) {
+      if (err?.code === 'PROJECT_NOT_FOUND') return res.status(404).json({ error: 'Project not found' });
+      res.status(500).json({ error: 'Book bible compile failed: ' + String(err?.message || err) });
+    }
+  });
+
+  // Fetch the currently persisted book bible.
+  app.get('/api/projects/:id/book-bible', async (req: Request, res: Response) => {
+    const engine = gateway.getProjectEngine?.();
+    if (!engine) return res.status(503).json({ error: 'Project engine not initialized' });
+    const project = engine.getProject(req.params.id);
+    if (!project) return res.status(404).json({ error: 'Project not found' });
+
+    try {
+      const content = await services.memory.getBookBibleEntry(String(req.params.id), 'book-bible.md');
+      if (content === null) {
+        return res.status(404).json({ error: 'Book bible has not been compiled yet. POST to this endpoint to generate it.' });
+      }
+      res.json({ content });
+    } catch (err: any) {
+      res.status(500).json({ error: 'Failed to load book bible: ' + String(err?.message || err) });
+    }
+  });
+}

--- a/gateway/src/api/routes/review.ts
+++ b/gateway/src/api/routes/review.ts
@@ -1,0 +1,315 @@
+/**
+ * Review API routes (M1.5 — ALP-1559).
+ *
+ * Exposes the M1 gated-human-review pipeline (M1.1 doc versioning, M1.2 gate
+ * state machine, M1.3 conductor wiring, M1.4 dirty dependency graph) over
+ * HTTP so the whole review loop — inspect a step's version history, diff two
+ * versions, approve or send back for revision, see what a change impacts
+ * downstream, and configure which phases/steps gate at all — is reachable
+ * without a UI (this file's own acceptance criteria: every route below is
+ * curl-exercisable end to end).
+ */
+import { Request, Response } from 'express';
+import { join } from 'path';
+import type { ApiContext } from '../context.js';
+import { docVersionService } from '../../services/doc-versions.js';
+import { computeTransitiveDependents } from '../../services/dependency-graph.js';
+import type { Project, ProjectStep } from '../../services/project-templates.js';
+
+/** Same slugification `step-executor.ts` uses for the on-disk project directory. */
+function projectDirFor(baseDir: string, project: Project): string {
+  const slug = project.title.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  return join(baseDir, 'workspace', 'projects', slug);
+}
+
+/** Same slugification `step-executor.ts` uses for a step's canonical pointer file. */
+function stepFileNameFor(step: ProjectStep): string {
+  return `${step.id}-${step.label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}.md`;
+}
+
+function findStep(project: Project, stepId: unknown): ProjectStep | undefined {
+  return project.steps.find((s) => s.id === stepId);
+}
+
+type DiffOp = { op: 'equal' | 'add' | 'remove'; line: string };
+
+/**
+ * Minimal line-level LCS diff — no external dependency for something this
+ * small. O(n*m) on line counts, which is fine for step-output-sized documents
+ * (hundreds to low thousands of lines, not whole-book manuscripts).
+ */
+function diffLines(fromText: string, toText: string): DiffOp[] {
+  const a = fromText.split('\n');
+  const b = toText.split('\n');
+  const n = a.length;
+  const m = b.length;
+
+  const lcs: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] = a[i] === b[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+
+  const ops: DiffOp[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      ops.push({ op: 'equal', line: a[i] });
+      i++; j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      ops.push({ op: 'remove', line: a[i] });
+      i++;
+    } else {
+      ops.push({ op: 'add', line: b[j] });
+      j++;
+    }
+  }
+  while (i < n) { ops.push({ op: 'remove', line: a[i] }); i++; }
+  while (j < m) { ops.push({ op: 'add', line: b[j] }); j++; }
+  return ops;
+}
+
+export function registerReviewRoutes(ctx: ApiContext): void {
+  const { app, gateway, baseDir } = ctx;
+  const workspaceDir = join(baseDir, 'workspace');
+
+  function getEngine(res: Response): any | null {
+    const engine = gateway.getProjectEngine?.();
+    if (!engine) {
+      res.status(503).json({ error: 'Project engine not initialized' });
+      return null;
+    }
+    return engine;
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  // Cross-book review queue
+  // ═══════════════════════════════════════════════════════════
+
+  // GET /api/reviews — every step (across every project/"book") currently
+  // awaiting a human decision. Registered before /api/projects/:id/... below
+  // is irrelevant — this is its own top-level path, no collision risk.
+  app.get('/api/reviews', (req: Request, res: Response) => {
+    const engine = getEngine(res);
+    if (!engine) return;
+
+    const projects: Project[] = engine.listProjects();
+    const queue = projects.flatMap((project) =>
+      project.steps
+        .filter((step) => step.status === 'awaiting_review')
+        .map((step) => ({
+          projectId: project.id,
+          projectTitle: project.title,
+          stepId: step.id,
+          stepLabel: step.label,
+          phase: step.phase,
+          gate: step.gate,
+          dirty: step.dirty,
+        })),
+    );
+
+    res.json({ queue, count: queue.length });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // Step version history
+  // ═══════════════════════════════════════════════════════════
+
+  app.get('/api/projects/:id/steps/:stepId/versions', async (req: Request, res: Response) => {
+    const engine = getEngine(res);
+    if (!engine) return;
+    const project: Project | undefined = engine.getProject(req.params.id);
+    if (!project) return res.status(404).json({ error: 'Project not found' });
+    const step = findStep(project, req.params.stepId);
+    if (!step) return res.status(404).json({ error: 'Step not found' });
+
+    const projectDir = projectDirFor(baseDir, project);
+    const canonicalPath = join(projectDir, stepFileNameFor(step));
+    const versions = await docVersionService.getVersions(projectDir, step.id, canonicalPath);
+    res.json({ stepId: step.id, versions });
+  });
+
+  app.get('/api/projects/:id/steps/:stepId/versions/:v', async (req: Request, res: Response) => {
+    const engine = getEngine(res);
+    if (!engine) return;
+    const project: Project | undefined = engine.getProject(req.params.id);
+    if (!project) return res.status(404).json({ error: 'Project not found' });
+    const step = findStep(project, req.params.stepId);
+    if (!step) return res.status(404).json({ error: 'Step not found' });
+
+    const versionNumber = Number(req.params.v);
+    if (!Number.isInteger(versionNumber) || versionNumber < 1) {
+      return res.status(400).json({ error: 'Version must be a positive integer' });
+    }
+
+    const projectDir = projectDirFor(baseDir, project);
+    const content = await docVersionService.getVersionContent(projectDir, step.id, versionNumber);
+    if (content === null) return res.status(404).json({ error: `Version v${versionNumber} not found` });
+    res.json({ stepId: step.id, v: versionNumber, content });
+  });
+
+  app.get('/api/projects/:id/steps/:stepId/diff', async (req: Request, res: Response) => {
+    const engine = getEngine(res);
+    if (!engine) return;
+    const project: Project | undefined = engine.getProject(req.params.id);
+    if (!project) return res.status(404).json({ error: 'Project not found' });
+    const step = findStep(project, req.params.stepId);
+    if (!step) return res.status(404).json({ error: 'Step not found' });
+
+    const from = Number(req.query.from);
+    const to = Number(req.query.to);
+    if (!Number.isInteger(from) || !Number.isInteger(to) || from < 1 || to < 1) {
+      return res.status(400).json({ error: 'from and to query params must be positive integers' });
+    }
+
+    const projectDir = projectDirFor(baseDir, project);
+    const [fromContent, toContent] = await Promise.all([
+      docVersionService.getVersionContent(projectDir, step.id, from),
+      docVersionService.getVersionContent(projectDir, step.id, to),
+    ]);
+    if (fromContent === null) return res.status(404).json({ error: `Version v${from} not found` });
+    if (toContent === null) return res.status(404).json({ error: `Version v${to} not found` });
+
+    res.json({ stepId: step.id, from, to, diff: diffLines(fromContent, toContent) });
+  });
+
+  // Manual save -> new version. Lets a reviewer edit a step's content directly
+  // (e.g. a quick typo fix) without going through an agent rerun.
+  app.post('/api/projects/:id/steps/:stepId/versions', async (req: Request, res: Response) => {
+    const engine = getEngine(res);
+    if (!engine) return;
+    const project: Project | undefined = engine.getProject(req.params.id);
+    if (!project) return res.status(404).json({ error: 'Project not found' });
+    const step = findStep(project, req.params.stepId);
+    if (!step) return res.status(404).json({ error: 'Step not found' });
+
+    const { content, note } = req.body || {};
+    if (typeof content !== 'string' || !content.trim()) {
+      return res.status(400).json({ error: 'content (non-empty string) required' });
+    }
+
+    const { writeFile, mkdir } = await import('fs/promises');
+    const projectDir = projectDirFor(baseDir, project);
+    await mkdir(projectDir, { recursive: true });
+    const version = await docVersionService.appendVersion(projectDir, step.id, content, 'user', note);
+    await writeFile(join(projectDir, stepFileNameFor(step)), content, 'utf-8');
+
+    const updated = engine.saveStepResult(project.id, step.id, content);
+    res.json({ stepId: step.id, version, step: updated });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // Gate decisions
+  // ═══════════════════════════════════════════════════════════
+
+  app.post('/api/projects/:id/steps/:stepId/approve', async (req: Request, res: Response) => {
+    const engine = getEngine(res);
+    if (!engine) return;
+    const project: Project | undefined = engine.getProject(req.params.id);
+    if (!project) return res.status(404).json({ error: 'Project not found' });
+    const step = findStep(project, req.params.stepId);
+    if (!step) return res.status(404).json({ error: 'Step not found' });
+    if (step.status !== 'awaiting_review') {
+      return res.status(400).json({ error: `Step is "${step.status}", not awaiting_review` });
+    }
+
+    const projectDir = projectDirFor(baseDir, project);
+    const currentVersion = await docVersionService.getCurrentVersion(projectDir, step.id);
+    const decided = engine.decideStepGate(project.id, step.id, 'approved', currentVersion);
+    res.json({ step: decided, project: engine.getProject(project.id) });
+  });
+
+  app.post('/api/projects/:id/steps/:stepId/revise', async (req: Request, res: Response) => {
+    const engine = getEngine(res);
+    if (!engine) return;
+    const project: Project | undefined = engine.getProject(req.params.id);
+    if (!project) return res.status(404).json({ error: 'Project not found' });
+    const step = findStep(project, req.params.stepId);
+    if (!step) return res.status(404).json({ error: 'Step not found' });
+
+    const { comments, notes } = req.body || {};
+    const feedback = [comments, notes].filter((s) => typeof s === 'string' && s.trim()).join('\n\n');
+    if (!feedback) {
+      return res.status(400).json({ error: 'comments and/or notes (string) required' });
+    }
+
+    const result = await engine.reviseStep(project.id, step.id, feedback, workspaceDir);
+
+    if (result.ok) {
+      return res.json({ success: true, response: result.response, version: result.version, project: result.project });
+    }
+    switch (result.kind) {
+      case 'no-project':
+        return res.status(404).json({ error: 'Project not found' });
+      case 'no-step':
+        return res.status(404).json({ error: 'Step not found' });
+      case 'not-awaiting-review':
+        return res.status(400).json({ error: `Step is "${step.status}", not awaiting_review` });
+      case 'provider-failure':
+        return res.json({ success: false, error: 'AI provider failure — see detail', detail: result.detail, project: result.project });
+      case 'short-response':
+        return res.json({ success: false, error: result.reason, project: result.project });
+      case 'error':
+        return res.status(500).json({ error: 'Revision failed: ' + result.error, project: result.project });
+    }
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // Downstream impact (M1.4 dependency graph)
+  // ═══════════════════════════════════════════════════════════
+
+  app.get('/api/projects/:id/steps/:stepId/impact', (req: Request, res: Response) => {
+    const engine = getEngine(res);
+    if (!engine) return;
+    const project: Project | undefined = engine.getProject(req.params.id);
+    if (!project) return res.status(404).json({ error: 'Project not found' });
+    const step = findStep(project, req.params.stepId);
+    if (!step) return res.status(404).json({ error: 'Step not found' });
+
+    const dependentIds = computeTransitiveDependents(project.steps, step.id);
+    const dirty = project.steps.filter((s) => dependentIds.has(s.id) && s.dirty);
+
+    res.json({
+      stepId: step.id,
+      downstreamStepIds: [...dependentIds],
+      dirty: dirty.map((s) => ({ stepId: s.id, label: s.label, marker: s.dirty })),
+    });
+  });
+
+  app.post('/api/projects/:id/steps/:stepId/clean', (req: Request, res: Response) => {
+    const engine = getEngine(res);
+    if (!engine) return;
+    const project: Project | undefined = engine.getProject(req.params.id);
+    if (!project) return res.status(404).json({ error: 'Project not found' });
+    const step = findStep(project, req.params.stepId);
+    if (!step) return res.status(404).json({ error: 'Step not found' });
+
+    const cleaned = engine.markStepClean(project.id, step.id);
+    res.json({ step: cleaned });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // Gate configuration
+  // ═══════════════════════════════════════════════════════════
+
+  // PATCH /api/projects/:id/gates — { reviewGates?: {phase: bool}, stepGateOverrides?: {stepId: bool|null} }
+  app.patch('/api/projects/:id/gates', (req: Request, res: Response) => {
+    const engine = getEngine(res);
+    if (!engine) return;
+    const project: Project | undefined = engine.getProject(req.params.id);
+    if (!project) return res.status(404).json({ error: 'Project not found' });
+
+    const { reviewGates, stepGateOverrides } = req.body || {};
+    if (reviewGates && (typeof reviewGates !== 'object' || Array.isArray(reviewGates))) {
+      return res.status(400).json({ error: 'reviewGates must be an object of {phase: boolean}' });
+    }
+    if (stepGateOverrides && (typeof stepGateOverrides !== 'object' || Array.isArray(stepGateOverrides))) {
+      return res.status(400).json({ error: 'stepGateOverrides must be an object of {stepId: boolean|null}' });
+    }
+
+    const updated = engine.updateReviewGates(project.id, { reviewGates, stepGateOverrides });
+    res.json({ project: updated });
+  });
+}

--- a/gateway/src/api/routes/system.ts
+++ b/gateway/src/api/routes/system.ts
@@ -433,8 +433,9 @@ export function registerSystemRoutes(ctx: ApiContext): void {
       'heartbeat.enableReminders', 'heartbeat.quietHoursStart',
       'heartbeat.quietHoursEnd', 'heartbeat.autonomousEnabled',
       'heartbeat.autonomousIntervalMinutes', 'heartbeat.maxAutonomousStepsPerWake',
-      'ai.defaultTemperature', 'ai.preferredProvider', 'ai.preferredImageProvider',
+      'ai.defaultTemperature', 'ai.preferredProvider', 'ai.preferredProviderFallback', 'ai.preferredImageProvider',
       'ai.ollama.enabled', 'ai.ollama.endpoint', 'ai.ollama.model',
+      'ai.openai.endpoint', 'ai.openai.model',
       'ai.openrouter.model',
       'bridges.telegram.enabled', 'bridges.telegram.pairingEnabled',
     ];
@@ -448,6 +449,9 @@ export function registerSystemRoutes(ctx: ApiContext): void {
       // Sync global provider preference to router
       if (path === 'ai.preferredProvider') {
         services.aiRouter.setGlobalPreferredProvider(value || null);
+      }
+      if (path === 'ai.preferredProviderFallback') {
+        services.aiRouter.setGlobalPreferredProviderFallback(value || null);
       }
       res.json({ success: true, path, value });
     } catch (err: any) {

--- a/gateway/src/cli/book.ts
+++ b/gateway/src/cli/book.ts
@@ -1,0 +1,121 @@
+/**
+ * `npm run book -- <command>` — manage per-book workspaces (ALP-1596).
+ *
+ * Switching the active book is restart-scoped: services are boot-time
+ * singletons (see workspace-routing.ts), so `use` only updates the
+ * `.active-book` pointer file. Restart the gateway for it to take effect.
+ */
+
+import { resolveInstallRootDir, loadInstallDotenv } from '../services/install-root.js';
+import {
+  resolveWorkspaceRoot,
+  looksLikeLegacyFlatWorkspace,
+  readActiveBookPointer,
+  writeActiveBookPointer,
+  listBooks,
+  scaffoldBookWorkspace,
+  migrateLegacyWorkspace,
+  slugifyBookName,
+  isValidBookSlug,
+} from '../services/workspace-routing.js';
+import { join } from 'path';
+import { existsSync } from 'fs';
+
+const ROOT_DIR = resolveInstallRootDir(import.meta.url, 3);
+loadInstallDotenv(ROOT_DIR);
+
+const ROOT = resolveWorkspaceRoot(process.env, join(ROOT_DIR, 'workspace'));
+
+function usage(): void {
+  console.log(`Usage: npm run book -- <command> [args]
+
+Commands:
+  list                    List book workspaces under the root and show which is active
+  create <name>           Scaffold a new, isolated book workspace ("<name>" is slugified)
+  use <slug>               Set the active book (restart the gateway to apply)
+  migrate-legacy [slug]    One-time move of an existing flat workspace into <root>/<slug>/
+                            (defaults slug to "default"), then sets it active
+
+Root: ${ROOT}`);
+}
+
+async function cmdList(): Promise<void> {
+  const legacy = looksLikeLegacyFlatWorkspace(ROOT);
+  const pointer = readActiveBookPointer(ROOT);
+  const books = await listBooks(ROOT);
+
+  if (legacy && !pointer) {
+    console.log(`Legacy flat workspace in place at ${ROOT} (no active-book selector set — this IS the workspace).`);
+  }
+  if (books.length === 0) {
+    console.log('No per-book workspaces found under the root.');
+    return;
+  }
+  console.log(`Books under ${ROOT}:`);
+  for (const book of books) {
+    console.log(`  ${book.active ? '*' : ' '} ${book.slug}`);
+  }
+}
+
+async function cmdCreate(rawName: string | undefined): Promise<void> {
+  if (!rawName) {
+    console.error('Usage: npm run book -- create <name>');
+    process.exitCode = 1;
+    return;
+  }
+  const slug = slugifyBookName(rawName);
+  const dir = await scaffoldBookWorkspace(ROOT, slug, ROOT_DIR);
+  console.log(`Created book workspace: ${dir}`);
+  console.log(`Run \`npm run book -- use ${slug}\` and restart the gateway to switch to it.`);
+}
+
+function cmdUse(slug: string | undefined): void {
+  if (!slug || !isValidBookSlug(slug)) {
+    console.error('Usage: npm run book -- use <slug>');
+    process.exitCode = 1;
+    return;
+  }
+  const bookDir = join(ROOT, slug);
+  if (!existsSync(bookDir)) {
+    console.error(`No book workspace found at ${bookDir}. Run \`npm run book -- create ${slug}\` or \`list\` first.`);
+    process.exitCode = 1;
+    return;
+  }
+  writeActiveBookPointer(ROOT, slug);
+  console.log(`Active book set to '${slug}'. Restart the gateway for this to take effect.`);
+}
+
+async function cmdMigrateLegacy(rawSlug: string | undefined): Promise<void> {
+  const slug = rawSlug ? slugifyBookName(rawSlug) : 'default';
+  const dir = await migrateLegacyWorkspace(ROOT, slug);
+  console.log(`Migrated legacy flat workspace into: ${dir}`);
+  console.log(`Active book set to '${slug}'. Restart the gateway for this to take effect.`);
+}
+
+async function main(): Promise<void> {
+  const [command, arg] = process.argv.slice(2);
+  try {
+    switch (command) {
+      case 'list':
+        await cmdList();
+        break;
+      case 'create':
+        await cmdCreate(arg);
+        break;
+      case 'use':
+        cmdUse(arg);
+        break;
+      case 'migrate-legacy':
+        await cmdMigrateLegacy(arg);
+        break;
+      default:
+        usage();
+        if (command) process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error(`book: ${(error as Error).message}`);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -6,16 +6,16 @@
  * Purpose: Fiction & nonfiction writing assistant
  */
 
-import { config as loadDotenv } from 'dotenv';
 import express from 'express';
 import { createServer } from 'http';
 import { Server as SocketIO } from 'socket.io';
 import cors from 'cors';
 import helmet from 'helmet';
-import { fileURLToPath } from 'url';
-import { dirname, join, resolve } from 'path';
+import { join } from 'path';
 import fs from 'fs/promises';
 import { existsSync } from 'fs';
+import { resolveInstallRootDir, loadInstallDotenv } from './services/install-root.js';
+import { resolveWorkspaceRoot, resolveActiveWorkspace } from './services/workspace-routing.js';
 
 import { ConfigService } from './services/config.js';
 import { MemoryService } from './services/memory.js';
@@ -92,39 +92,30 @@ import { logger } from './services/logger.js';
 import { ServiceContainer } from './services/container.js';
 import { MessagePipeline } from './services/message-pipeline.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const ROOT_DIR = __dirname.includes('dist')
-  ? join(__dirname, '..', '..', '..')
-  : join(__dirname, '..', '..');
+const ROOT_DIR = resolveInstallRootDir(import.meta.url, 2);
 
-// Load .env FIRST — before anything else reads process.env. Resolved
-// relative to ROOT_DIR (this file's own location), NOT process.cwd(). The
-// previous bare `import 'dotenv/config'` resolves .env relative to
-// whatever directory the process happens to be started FROM — if that's
-// ever anything other than this install's root (a different terminal, a
-// launcher, a scheduled task), it silently finds nothing and every env
-// override quietly reverts to its default, with no error at all. This is
-// exactly what happened to AUTHORCLAW_WORKSPACE_DIR: real work landed in
-// the wrong workspace for hours, invisible to git, before anyone noticed.
-const dotenvResult = loadDotenv({ path: join(ROOT_DIR, '.env') });
-// A missing .env is a normal, silent no-op for installs that don't use
-// one — but if AUTHORCLAW_WORKSPACE_DIR is set in the *shell* environment
-// while .env failed to load, that's worth a visible warning rather than a
-// silent fallback to the default path (console.warn, not the logger
-// service — that isn't constructed yet this early).
-if (dotenvResult.error && (dotenvResult.error as NodeJS.ErrnoException).code !== 'ENOENT') {
-  console.warn(`[startup] .env failed to load from ${join(ROOT_DIR, '.env')}: ${dotenvResult.error.message}`);
-}
+// Load .env FIRST — before anything else reads process.env. See
+// install-root.ts for why this must be resolved relative to ROOT_DIR (this
+// file's own location) rather than process.cwd() — a real incident where
+// AUTHORCLAW_WORKSPACE_DIR silently reverted to its default for hours.
+loadInstallDotenv(ROOT_DIR);
 
 // Where all live project data (book bible, chapters, memory, audit logs,
-// etc.) is stored. Defaults to <ROOT_DIR>/workspace as before; overridable
-// via AUTHORCLAW_WORKSPACE_DIR so this data can live somewhere other than
-// inside the AuthorAgent install itself — e.g. a separate git-tracked repo,
-// so manuscript history is decoupled from the tool's own version history.
-const WORKSPACE_DIR = process.env.AUTHORCLAW_WORKSPACE_DIR
-  ? resolve(process.env.AUTHORCLAW_WORKSPACE_DIR)
-  : join(ROOT_DIR, 'workspace');
+// etc.) is stored. AUTHORCLAW_WORKSPACE_DIR (or the AUTHORCLAW_PROJECTS_ROOT
+// alias) is now a ROOT that can hold MANY per-book workspaces at
+// `<root>/<book-slug>/`, selected via AUTHORCLAW_ACTIVE_BOOK or a
+// `<root>/.active-book` pointer file — see workspace-routing.ts. An existing
+// flat single-book install (memory/, soul/, projects/ directly under the
+// root, no active book selected) is detected as legacy and the root itself
+// is used unchanged, so no migration is required to keep it running.
+const WORKSPACE_ROOT = resolveWorkspaceRoot(process.env, join(ROOT_DIR, 'workspace'));
+const resolvedWorkspace = resolveActiveWorkspace(WORKSPACE_ROOT, process.env);
+const WORKSPACE_DIR = resolvedWorkspace.workspaceDir;
+if (resolvedWorkspace.mode === 'active-book') {
+  console.log(`[startup] Active book: ${resolvedWorkspace.activeBook} (${WORKSPACE_DIR})`);
+} else if (resolvedWorkspace.mode === 'default-book') {
+  console.log(`[startup] No active book selected — defaulting to '${resolvedWorkspace.activeBook}' (${WORKSPACE_DIR}). Run \`npm run book -- create <slug>\` and \`npm run book -- use <slug>\` to add more books.`);
+}
 
 // ═══════════════════════════════════════════════════════════
 // AuthorAgent Gateway

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -15,7 +15,7 @@ import { Server as SocketIO } from 'socket.io';
 import cors from 'cors';
 import helmet from 'helmet';
 import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { dirname, join, resolve } from 'path';
 import fs from 'fs/promises';
 import { existsSync } from 'fs';
 
@@ -99,6 +99,15 @@ const __dirname = dirname(__filename);
 const ROOT_DIR = __dirname.includes('dist')
   ? join(__dirname, '..', '..', '..')
   : join(__dirname, '..', '..');
+
+// Where all live project data (book bible, chapters, memory, audit logs,
+// etc.) is stored. Defaults to <ROOT_DIR>/workspace as before; overridable
+// via AUTHORCLAW_WORKSPACE_DIR so this data can live somewhere other than
+// inside the AuthorAgent install itself — e.g. a separate git-tracked repo,
+// so manuscript history is decoupled from the tool's own version history.
+const WORKSPACE_DIR = process.env.AUTHORCLAW_WORKSPACE_DIR
+  ? resolve(process.env.AUTHORCLAW_WORKSPACE_DIR)
+  : join(ROOT_DIR, 'workspace');
 
 // ═══════════════════════════════════════════════════════════
 // AuthorAgent Gateway
@@ -342,34 +351,34 @@ class AuthorAgentGateway {
     this.permissions = new PermissionManager(this.config.get('security.permissionPreset', 'standard'));
     logger.info(`  ✓ Permissions: ${this.permissions.preset} mode`);
 
-    this.audit = new AuditLog(join(ROOT_DIR, 'workspace', '.audit'));
+    this.audit = new AuditLog(join(WORKSPACE_DIR, '.audit'));
     await this.audit.initialize();
     logger.info('  ✓ Audit logging active');
 
-    this.sandbox = new SandboxGuard(join(ROOT_DIR, 'workspace'));
+    this.sandbox = new SandboxGuard(WORKSPACE_DIR);
     logger.info('  ✓ Sandbox: workspace-only file access');
 
     this.injectionDetector = new InjectionDetector();
     logger.info('  ✓ Prompt injection detection active');
 
     // ── Phase 2b: Activity Log ──
-    this.activityLog = new ActivityLog(join(ROOT_DIR, 'workspace'));
+    this.activityLog = new ActivityLog(WORKSPACE_DIR);
     await this.activityLog.initialize();
     logger.info('  ✓ Activity log initialized');
 
     // ── Phase 3: Soul & Memory ──
-    this.soul = new SoulService(join(ROOT_DIR, 'workspace', 'soul'));
+    this.soul = new SoulService(join(WORKSPACE_DIR, 'soul'));
     await this.soul.load();
     logger.info(`  ✓ Soul loaded: "${this.soul.getName()}"`);
 
-    this.memory = new MemoryService(join(ROOT_DIR, 'workspace', 'memory'), this.config.get('memory'));
+    this.memory = new MemoryService(join(WORKSPACE_DIR, 'memory'), this.config.get('memory'));
     await this.memory.initialize();
     logger.info('  ✓ Memory system initialized');
 
     // ── Phase 3b: Memory Search (FTS5 over conversations + project outputs) ──
     // Hermes-inspired persistent cross-session search. Falls back gracefully
     // if better-sqlite3 isn't available on this platform.
-    this.memorySearch = new MemorySearchService(join(ROOT_DIR, 'workspace'));
+    this.memorySearch = new MemorySearchService(WORKSPACE_DIR);
     await this.memorySearch.initialize();
     if (this.memorySearch.isAvailable()) {
       // Wire memory.process() → live FTS indexing
@@ -388,12 +397,12 @@ class AuthorAgentGateway {
 
     // ── Phase 4: AI Providers ──
     const costsConfig = this.config.get('costs') || {};
-    costsConfig.persistPath = join(ROOT_DIR, 'workspace', 'costs.json');
+    costsConfig.persistPath = join(WORKSPACE_DIR, 'costs.json');
     this.costs = new CostTracker(costsConfig);
     await this.costs.initialize();
     logger.info(`  ✓ Budget: $${this.costs.dailyLimit}/day, $${this.costs.monthlyLimit}/month (persisted)`);
 
-    this.aiRouter = new AIRouter(this.config.get('ai'), this.vault, this.costs, join(ROOT_DIR, 'workspace'));
+    this.aiRouter = new AIRouter(this.config.get('ai'), this.vault, this.costs, WORKSPACE_DIR);
     await this.aiRouter.initialize();
     // Load global preferred provider from config
     const globalPref = this.config.get('ai.preferredProvider');
@@ -421,7 +430,7 @@ class AuthorAgentGateway {
     logger.info(`  ✓ Research gate: ${this.research.getAllowedDomainCount()} approved domains`);
 
     // ── Phase 6: Skills ──
-    this.skills = new SkillLoader(join(ROOT_DIR, 'skills'), this.permissions, join(ROOT_DIR, 'workspace'));
+    this.skills = new SkillLoader(join(ROOT_DIR, 'skills'), this.permissions, WORKSPACE_DIR);
     await this.skills.loadAll();
     const premiumCount = this.skills.getPremiumSkillCount();
     const premiumLabel = premiumCount > 0 ? `, ${premiumCount} premium ★` : '';
@@ -478,15 +487,15 @@ class AuthorAgentGateway {
     }
 
     // ── Phase 6c: TTS Service (Piper) — silent init, optional feature ──
-    this.tts = new TTSService(join(ROOT_DIR, 'workspace'), this.vault);
+    this.tts = new TTSService(WORKSPACE_DIR, this.vault);
     await this.tts.initialize();
 
     // ── Phase 6c2: Image Generation Service ──
-    this.imageGen = new ImageGenService(join(ROOT_DIR, 'workspace'), this.vault);
+    this.imageGen = new ImageGenService(WORKSPACE_DIR, this.vault);
     await this.imageGen.initialize();
 
     // ── Phase 6d: Author Personas ──
-    this.personas = new PersonaService(join(ROOT_DIR, 'workspace'));
+    this.personas = new PersonaService(WORKSPACE_DIR);
     await this.personas.initialize();
     logger.info(`  ✓ Personas: ${this.personas.getCount()} author persona(s) loaded`);
 
@@ -501,7 +510,7 @@ class AuthorAgentGateway {
     logger.info(`  ✓ Project engine: ${templates.length} templates + dynamic AI planning`);
 
     // ── Phase 6f: Context Engine ──
-    this.contextEngine = new ContextEngine(join(ROOT_DIR, 'workspace'));
+    this.contextEngine = new ContextEngine(WORKSPACE_DIR);
     this.projectEngine.setContextEngine(this.contextEngine);
     logger.info('  ✓ Context Engine: manuscript memory + continuity checking');
 
@@ -513,7 +522,7 @@ class AuthorAgentGateway {
     this.memoryTier = new MemoryTierService(
       this.contextEngine,
       this.memorySearch?.isAvailable() ? this.memorySearch : null,
-      join(ROOT_DIR, 'workspace'),
+      WORKSPACE_DIR,
     );
     this.projectEngine.setMemoryTier(this.memoryTier);
     logger.info(`  ✓ Memory tier: CORE budgeting + ARCHIVAL search (${this.memorySearch?.isAvailable() ? 'search on' : 'search off'})`);
@@ -529,11 +538,11 @@ class AuthorAgentGateway {
     );
 
     // ── Phase 6g: Lessons & Preferences (from Sneakers) ──
-    this.lessons = new LessonStore(join(ROOT_DIR, 'workspace', 'memory'));
+    this.lessons = new LessonStore(join(WORKSPACE_DIR, 'memory'));
     await this.lessons.initialize();
     logger.info(`  ✓ Lessons: ${this.lessons.getAll().length} learned`);
 
-    this.preferences = new PreferenceStore(join(ROOT_DIR, 'workspace', 'memory'));
+    this.preferences = new PreferenceStore(join(WORKSPACE_DIR, 'memory'));
     await this.preferences.initialize();
     const prefCount = Object.keys(this.preferences.getAll()).length;
     logger.info(`  ✓ Preferences: ${prefCount} tracked`);
@@ -541,7 +550,7 @@ class AuthorAgentGateway {
     // ── Phase 6g2: User Model (Honcho-style dialectic, simplified) ──
     // Tracks behavioral observations + per-persona breakdown + periodically
     // consolidates them into an LLM-generated narrative profile.
-    this.userModel = new UserModelService(join(ROOT_DIR, 'workspace'));
+    this.userModel = new UserModelService(WORKSPACE_DIR);
     this.userModel.setAI(
       (req) => this.aiRouter.complete(req),
       (taskType: string) => this.aiRouter.selectProvider(taskType),
@@ -551,7 +560,7 @@ class AuthorAgentGateway {
     logger.info(`  ✓ User model: ${um?.observationCount || 0} observations${um?.narrative.confidence ? `, narrative confidence ${(um.narrative.confidence * 100).toFixed(0)}%` : ''}`);
 
     // ── Phase 6g3: Cron Scheduler (Hermes-inspired) ──
-    this.cronScheduler = new CronSchedulerService(join(ROOT_DIR, 'workspace'));
+    this.cronScheduler = new CronSchedulerService(WORKSPACE_DIR);
     await this.cronScheduler.initialize();
     // Register built-in handlers — user-created jobs reference these by name.
     this.cronScheduler.registerHandler('reindex-memory-search', async () => {
@@ -693,7 +702,7 @@ class AuthorAgentGateway {
     this.researchLookup = new ResearchLookupService();
     this.researchLookup.setDependencies(this.vault, this.aiRouter);
 
-    this.videoResearch = new VideoResearchService(join(ROOT_DIR, 'workspace'));
+    this.videoResearch = new VideoResearchService(WORKSPACE_DIR);
     this.videoResearch.setDependencies(this.vault, this.aiRouter);
     const videoDoctor = await this.videoResearch.doctor();
     if (videoDoctor.ready) {
@@ -707,18 +716,18 @@ class AuthorAgentGateway {
     logger.info(`  ✓ Story structures: ${this.storyStructures.list().length} structures available (Save the Cat, three-act, five-act / Freytag, Seven-Point / Wells, Hero's Journey, Romancing the Beat, Story Circle, Mystery 5-Stage, Martell Thematic, none)`);
 
     // ── Phase 6g8: Plot Promises (Sanderson-style promises + payoffs) ──
-    this.plotPromises = new PlotPromisesService(join(ROOT_DIR, 'workspace'));
+    this.plotPromises = new PlotPromisesService(WORKSPACE_DIR);
     await this.plotPromises.initialize();
     logger.info(`  ✓ Plot promises: tracker ready`);
 
     // ── Phase 6g9: Character voices (per-character StyleClone fingerprinting) ──
-    this.characterVoices = new CharacterVoicesService(join(ROOT_DIR, 'workspace'));
+    this.characterVoices = new CharacterVoicesService(WORKSPACE_DIR);
     this.characterVoices.setStyleClone(this.styleClone);
     await this.characterVoices.initialize();
     logger.info(`  ✓ Character voices: per-character voice drift tracker ready`);
 
     // ── Phase 6h: Website management — auto-add-book, blog drafter, deploy ──
-    this.websiteSites = new WebsiteSiteService(join(ROOT_DIR, 'workspace'));
+    this.websiteSites = new WebsiteSiteService(WORKSPACE_DIR);
     await this.websiteSites.initialize();
     this.blogPostDrafter = new BlogPostDrafterService();
     this.websiteDeploy = new WebsiteDeployService();
@@ -792,7 +801,7 @@ class AuthorAgentGateway {
     });
 
     // ── Phase 6h: Orchestrator (script manager) ──
-    this.orchestrator = new OrchestratorService(join(ROOT_DIR, 'workspace'));
+    this.orchestrator = new OrchestratorService(WORKSPACE_DIR);
     await this.orchestrator.initialize();
     const scriptCount = this.orchestrator.getConfigs().length;
     logger.info(`  ✓ Orchestrator: ${scriptCount} script(s) configured`);
@@ -810,11 +819,11 @@ class AuthorAgentGateway {
     logger.info('  ✓ KDP exporter, beta reader, dialogue auditor, hub, cover typography, external tools, track-changes ready');
 
     // ── Phase 6j: Wave 2 — career/craft/series/audiobook/voice ──
-    this.goalsService = new GoalsService(join(ROOT_DIR, 'workspace'));
+    this.goalsService = new GoalsService(WORKSPACE_DIR);
     await this.goalsService.initialize();
     logger.info(`  ✓ Author goals: ${this.goalsService.listGoals().length} tracked`);
 
-    this.seriesBible = new SeriesBibleService(join(ROOT_DIR, 'workspace'));
+    this.seriesBible = new SeriesBibleService(WORKSPACE_DIR);
     await this.seriesBible.initialize();
     logger.info(`  ✓ Series bible: ${this.seriesBible.listSeries().length} series`);
 
@@ -834,7 +843,7 @@ class AuthorAgentGateway {
       projects: this.projectEngine,
       aiComplete: (request) => this.aiRouter.complete(request),
       aiSelectProvider: (taskType: string) => this.aiRouter.selectProvider(taskType),
-      workspaceDir: join(ROOT_DIR, 'workspace'),
+      workspaceDir: WORKSPACE_DIR,
     });
     logger.info('  ✓ Sleep consolidation: CoreDigest materialization + free-tier passes ready');
 
@@ -843,7 +852,7 @@ class AuthorAgentGateway {
     // distills free-tier comment themes so future chapters can be drafted
     // with real reader-reaction data. Wattpad is an honest stub.
     this.readerFeedback = new ReaderFeedbackService({
-      workspaceDir: join(ROOT_DIR, 'workspace'),
+      workspaceDir: WORKSPACE_DIR,
       aiComplete: (request) => this.aiRouter.complete(request),
       aiSelectProvider: (taskType: string) => this.aiRouter.selectProvider(taskType),
     });
@@ -908,14 +917,14 @@ class AuthorAgentGateway {
     logger.info('  ✓ Learning service: recurring-issue → durable-lesson loop ready');
 
     // ── Phase 6k: Wave 3 — autonomous career agent (gated) ──
-    this.confirmationGate = new ConfirmationGateService(join(ROOT_DIR, 'workspace'));
+    this.confirmationGate = new ConfirmationGateService(WORKSPACE_DIR);
     this.confirmationGate.setAuditLogger((category, action, meta) => this.audit.log(category, action, meta));
     await this.confirmationGate.initialize();
     logger.info(`  ✓ Confirmation gate: ${this.confirmationGate.list({ status: 'pending' }).length} pending`);
 
     this.disclosures = new DisclosuresService();
 
-    this.launchOrchestrator = new LaunchOrchestratorService(join(ROOT_DIR, 'workspace'));
+    this.launchOrchestrator = new LaunchOrchestratorService(WORKSPACE_DIR);
     this.launchOrchestrator.setDependencies(this.confirmationGate, this.disclosures);
     await this.launchOrchestrator.initialize();
     logger.info(`  ✓ Launch orchestrator: ${this.launchOrchestrator.listLaunches().length} launch(es) tracked`);
@@ -923,7 +932,7 @@ class AuthorAgentGateway {
     this.amsAds = new AMSAdsService();
     this.bookbub = new BookBubSubmitterService();
 
-    this.releaseCalendar = new ReleaseCalendarService(join(ROOT_DIR, 'workspace'));
+    this.releaseCalendar = new ReleaseCalendarService(WORKSPACE_DIR);
     await this.releaseCalendar.initialize();
     logger.info(`  ✓ Release calendar: ${this.releaseCalendar.list().length} event(s)`);
 
@@ -936,12 +945,12 @@ class AuthorAgentGateway {
       (taskType: string) => this.aiRouter.selectProvider(taskType),
     );
 
-    this.websiteBuilder = new WebsiteBuilderService(join(ROOT_DIR, 'workspace'));
+    this.websiteBuilder = new WebsiteBuilderService(WORKSPACE_DIR);
     logger.info('  ✓ AMS, BookBub, Reader Intel, Translation, Website Builder ready');
     logger.warn('  ⚠ Wave 3 actions are gated — review SECURITY.md and confirm every external action.');
 
     // ── Phase 7: Heartbeat ──
-    this.heartbeat = new HeartbeatService(this.config.get('heartbeat'), this.memory, join(ROOT_DIR, 'workspace'));
+    this.heartbeat = new HeartbeatService(this.config.get('heartbeat'), this.memory, WORKSPACE_DIR);
 
     // Wire autonomous mode — heartbeat can now trigger project steps on a schedule
     const commandHandlers = this.buildTelegramCommandHandlers();
@@ -1002,7 +1011,7 @@ class AuthorAgentGateway {
           const parsed = JSON.parse(cleaned);
 
           // Save to self-improve log
-          const workspaceDir = join(ROOT_DIR, 'workspace');
+          const workspaceDir = WORKSPACE_DIR;
           const agentDir = join(workspaceDir, '.agent');
           await fs.mkdir(agentDir, { recursive: true });
           const logPath = join(agentDir, 'self-improve-log.json');
@@ -1104,7 +1113,7 @@ class AuthorAgentGateway {
       // Loads tasks from workspace/.config/idle-tasks.json (user-editable via dashboard)
       async () => {
         // Load tasks from config file, falling back to defaults
-        const idleConfigPath = join(ROOT_DIR, 'workspace', '.config', 'idle-tasks.json');
+        const idleConfigPath = join(WORKSPACE_DIR, '.config', 'idle-tasks.json');
         let idleTasks: Array<{ label: string; prompt: string; enabled?: boolean }> = [];
         try {
           if ((await import('fs')).existsSync(idleConfigPath)) {
@@ -1118,7 +1127,7 @@ class AuthorAgentGateway {
           idleTasks = (await import('./services/idle-tasks-defaults.js')).DEFAULT_IDLE_TASKS;
           // Save defaults on first run
           try {
-            const configDir = join(ROOT_DIR, 'workspace', '.config');
+            const configDir = join(WORKSPACE_DIR, '.config');
             await fs.mkdir(configDir, { recursive: true });
             await fs.writeFile(idleConfigPath, JSON.stringify({ tasks: idleTasks }, null, 2), 'utf-8');
           } catch { /* non-fatal */ }
@@ -1140,7 +1149,7 @@ class AuthorAgentGateway {
 
           if (result.text && result.text.length > 20) {
             // Save to workspace
-            const idleDir = join(ROOT_DIR, 'workspace', '.agent');
+            const idleDir = join(WORKSPACE_DIR, '.agent');
             await fs.mkdir(idleDir, { recursive: true });
             const dateStr = new Date().toISOString().split('T')[0];
             await fs.writeFile(
@@ -1418,7 +1427,7 @@ class AuthorAgentGateway {
     const parts = input.split(/\s+/);
     const cmd = parts[0].toLowerCase();
     const args = input.substring(cmd.length).trim();
-    const workspaceDir = join(ROOT_DIR, 'workspace');
+    const workspaceDir = WORKSPACE_DIR;
     const handlers = this.buildTelegramCommandHandlers();
 
     // Natural language commands (no slash prefix)
@@ -1977,7 +1986,7 @@ class AuthorAgentGateway {
    */
   private buildTelegramCommandHandlers() {
     const gateway = this;
-    const workspaceDir = join(ROOT_DIR, 'workspace');
+    const workspaceDir = WORKSPACE_DIR;
 
     return {
       /**

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -272,7 +272,21 @@ class AuthorAgentGateway {
     this.app = express();
     this.server = createServer(this.app);
     this.io = new SocketIO(this.server, {
-      cors: { origin: ['http://localhost:3847', 'http://127.0.0.1:3847'] },
+      cors: {
+        origin: (origin, callback) => {
+          if (!origin || this.getAllowedOrigins().includes(origin)) return callback(null, true);
+          callback(new Error('Not allowed by CORS'));
+        },
+      },
+    });
+    // Diagnostic: Engine.IO's own handshake-failure event, fires BEFORE
+    // io.on('connection') for anything rejected during the handshake
+    // (bad origin, transport error, etc.) — otherwise these fail silently.
+    this.io.engine.on('connection_error', (err: any) => {
+      logger.warn(
+        `[websocket] handshake failed: code=${err.code} message="${err.message}" ` +
+        `origin=${err.req?.headers?.origin || 'none'} url=${err.req?.url || 'unknown'}`
+      );
     });
 
     // Security middleware
@@ -283,6 +297,16 @@ class AuthorAgentGateway {
           scriptSrc: ["'self'", "'unsafe-inline'"],
           styleSrc: ["'self'", "'unsafe-inline'"],
           connectSrc: ["'self'", "http://localhost:3847", "http://127.0.0.1:3847"],
+          // Helmet's default CSP directive set auto-injects
+          // upgrade-insecure-requests, which makes the browser silently
+          // rewrite every http:// fetch this page makes to https://. Browsers
+          // exempt localhost/127.0.0.1 from that rewrite (they're
+          // "potentially trustworthy" origins) but NOT other addresses like a
+          // Tailscale IP — so with this directive active, every API call from
+          // a non-localhost origin gets rewritten to https:// and fails with
+          // ERR_SSL_PROTOCOL_ERROR against this plain-HTTP server. Explicitly
+          // nulling it out here removes it from the generated header.
+          upgradeInsecureRequests: null,
         },
       },
     }));
@@ -376,6 +400,11 @@ class AuthorAgentGateway {
     if (globalPref) {
       this.aiRouter.setGlobalPreferredProvider(globalPref);
       logger.info(`  ✓ Global preferred provider: ${globalPref}`);
+    }
+    const globalPrefFallback = this.config.get('ai.preferredProviderFallback');
+    if (globalPrefFallback) {
+      this.aiRouter.setGlobalPreferredProviderFallback(globalPrefFallback);
+      logger.info(`  ✓ Preferred provider fallback: ${globalPrefFallback}`);
     }
     const providers = this.aiRouter.getActiveProviders();
     for (const p of providers) {
@@ -1236,15 +1265,32 @@ class AuthorAgentGateway {
     logger.info('');
     logger.info('  ═══════════════════════════════════');
     logger.info('  ✍️  AuthorAgent is ready to write');
-    logger.info(`  📡 Dashboard: http://localhost:${this.config.get('server.port', 3847)}`);
+    logger.info(`  📡 Dashboard: http://${this.config.get('server.host', 'localhost')}:${this.config.get('server.port', 3847)}`);
     logger.info('  ═══════════════════════════════════');
     logger.info('');
+  }
+
+  /**
+   * Origins allowed to talk to the API/WebSocket. Always includes localhost
+   * (dashboard opened directly on this machine); also includes the
+   * configured `server.host`:port when it's been set to something other than
+   * localhost (e.g. a Tailscale IP), so the dashboard still works when
+   * accessed remotely from a non-localhost origin.
+   */
+  private getAllowedOrigins(): string[] {
+    const port = this.config?.get?.('server.port', 3847) ?? 3847;
+    const allowed = [`http://localhost:${port}`, `http://127.0.0.1:${port}`];
+    const host = this.config?.get?.('server.host', '127.0.0.1');
+    if (host && host !== '127.0.0.1' && host !== 'localhost') {
+      allowed.push(`http://${host}:${port}`);
+    }
+    return allowed;
   }
 
   private setupWebSocket(): void {
     this.io.on('connection', (socket) => {
       const origin = socket.handshake.headers.origin;
-      const allowed = ['http://localhost:3847', 'http://127.0.0.1:3847'];
+      const allowed = this.getAllowedOrigins();
       if (origin && !allowed.includes(origin)) {
         this.audit.log('security', 'websocket_rejected', { origin });
         socket.disconnect();
@@ -2489,8 +2535,25 @@ class AuthorAgentGateway {
   async start(): Promise<void> {
     await this.initialize();
     const port = this.config.get('server.port', 3847);
-    this.server.listen(port, '127.0.0.1', () => {
-      // Bound to localhost only for security
+    const host = this.config.get('server.host', '127.0.0.1');
+    // Without this handler, a bind failure (port in use, or — since host is
+    // config-driven and can be set to a Tailscale/LAN IP — that interface
+    // dropping or not being up yet at boot) throws as an unhandled 'error'
+    // event and crashes the whole process with no diagnostic in the log
+    // beyond a bare non-zero exit code.
+    this.server.on('error', (err: NodeJS.ErrnoException) => {
+      logger.error(`  ✗ Server failed to bind ${host}:${port}: ${err.code || err.message}`);
+      if (err.code === 'EADDRNOTAVAIL') {
+        logger.error(`    Address ${host} is not currently assigned to any network interface on this machine.`);
+      } else if (err.code === 'EADDRINUSE') {
+        logger.error(`    Port ${port} is already in use — another AuthorAgent instance (or something else) is bound to it.`);
+      }
+      process.exit(1);
+    });
+    this.server.listen(port, host, () => {
+      // Bind address is config-driven (server.host in config/user.json).
+      // Defaults to localhost-only; see getAllowedOrigins() for the matching
+      // CORS/WebSocket origin allowlist when host is set to something else.
     });
   }
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -6,9 +6,7 @@
  * Purpose: Fiction & nonfiction writing assistant
  */
 
-// Load .env file FIRST — before anything reads process.env
-import 'dotenv/config';
-
+import { config as loadDotenv } from 'dotenv';
 import express from 'express';
 import { createServer } from 'http';
 import { Server as SocketIO } from 'socket.io';
@@ -99,6 +97,25 @@ const __dirname = dirname(__filename);
 const ROOT_DIR = __dirname.includes('dist')
   ? join(__dirname, '..', '..', '..')
   : join(__dirname, '..', '..');
+
+// Load .env FIRST — before anything else reads process.env. Resolved
+// relative to ROOT_DIR (this file's own location), NOT process.cwd(). The
+// previous bare `import 'dotenv/config'` resolves .env relative to
+// whatever directory the process happens to be started FROM — if that's
+// ever anything other than this install's root (a different terminal, a
+// launcher, a scheduled task), it silently finds nothing and every env
+// override quietly reverts to its default, with no error at all. This is
+// exactly what happened to AUTHORCLAW_WORKSPACE_DIR: real work landed in
+// the wrong workspace for hours, invisible to git, before anyone noticed.
+const dotenvResult = loadDotenv({ path: join(ROOT_DIR, '.env') });
+// A missing .env is a normal, silent no-op for installs that don't use
+// one — but if AUTHORCLAW_WORKSPACE_DIR is set in the *shell* environment
+// while .env failed to load, that's worth a visible warning rather than a
+// silent fallback to the default path (console.warn, not the logger
+// service — that isn't constructed yet this early).
+if (dotenvResult.error && (dotenvResult.error as NodeJS.ErrnoException).code !== 'ENOENT') {
+  console.warn(`[startup] .env failed to load from ${join(ROOT_DIR, '.env')}: ${dotenvResult.error.message}`);
+}
 
 // Where all live project data (book bible, chapters, memory, audit logs,
 // etc.) is stored. Defaults to <ROOT_DIR>/workspace as before; overridable

--- a/gateway/src/services/activity-log.ts
+++ b/gateway/src/services/activity-log.ts
@@ -20,6 +20,7 @@ export type ActivityType =
   | 'step_started'
   | 'step_completed'
   | 'step_failed'
+  | 'gate_opened'
   | 'chat_message'
   | 'skill_matched'
   | 'file_saved'

--- a/gateway/src/services/book-bible.test.ts
+++ b/gateway/src/services/book-bible.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { ContextEngine, type ProjectContext } from './context-engine.js';
+import { BookBibleService, type ProjectEngineLike, type ProjectLike } from './book-bible.js';
+
+let workspaceDir: string;
+let contextEngine: ContextEngine;
+let service: BookBibleService;
+
+function seedContext(ctx: ProjectContext) {
+  const contextDir = join(workspaceDir, 'context');
+  mkdirSync(contextDir, { recursive: true });
+  writeFileSync(join(contextDir, `${ctx.projectId}.json`), JSON.stringify(ctx, null, 2), 'utf-8');
+}
+
+function project(overrides: Partial<ProjectLike> & { id: string; title: string }): ProjectLike {
+  return { steps: [], ...overrides };
+}
+
+function fakeEngine(projects: ProjectLike[]): ProjectEngineLike {
+  return {
+    getProject: (id: string) => projects.find(p => p.id === id),
+    listProjects: () => projects,
+  };
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), 'authoragent-book-bible-'));
+  contextEngine = new ContextEngine(workspaceDir);
+  service = new BookBibleService(workspaceDir);
+});
+
+afterEach(() => {
+  try { rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('BookBibleService.compile — entity index -> rendered sections', () => {
+  it('renders characters, timeline, locations, world rules, and items from the ContextEngine index', async () => {
+    seedContext({
+      projectId: 'project-1',
+      updatedAt: new Date().toISOString(),
+      summaries: [
+        {
+          chapterId: 'project-1-step-1', chapterNumber: 1, title: 'Opening',
+          summary: 'Aria meets Kael at the docks.', wordCount: 3000,
+          characters: ['Aria', 'Kael'], locations: ['Docks'],
+          timelineMarker: 'Day 1', plotThreads: ['the missing heir'],
+          endingState: 'Aria sets out to find the heir.',
+        },
+      ],
+      entities: [
+        {
+          name: 'Aria', type: 'character', aliases: ['The Courier'],
+          description: 'A dockside courier.', firstAppearance: 'project-1-step-1', lastSeen: 'project-1-step-1',
+          attributes: { role: 'protagonist' }, changes: [{ chapterId: 'project-1-step-1', description: 'learned to pick locks' }],
+        },
+        {
+          name: 'The Docks', type: 'location', aliases: [],
+          description: 'A foggy harbor district.', firstAppearance: 'project-1-step-1', lastSeen: 'project-1-step-1',
+          attributes: {}, changes: [],
+        },
+        {
+          name: 'Magic requires blood', type: 'rule', aliases: [],
+          description: 'All magic costs the caster blood.', firstAppearance: 'project-1-step-1', lastSeen: 'project-1-step-1',
+          attributes: {}, changes: [],
+        },
+        {
+          name: 'The Sealed Vault', type: 'item', aliases: [],
+          description: 'An ancient vault that hums.', firstAppearance: 'project-1-step-1', lastSeen: 'project-1-step-1',
+          attributes: {}, changes: [],
+        },
+      ],
+    });
+
+    const engine = fakeEngine([project({ id: 'project-1', title: 'The Algorithm of Wanting' })]);
+    const result = await service.compile(engine, contextEngine, 'project-1');
+
+    expect(result.counts).toEqual({
+      characters: 1, locations: 1, items: 1, events: 0, rules: 1, chapters: 1, planningNotes: 0,
+    });
+    expect(result.content).toContain('# The Algorithm of Wanting — Book Bible');
+    expect(result.content).toContain('## Characters');
+    expect(result.content).toContain('### Aria (The Courier)');
+    expect(result.content).toContain('A dockside courier.');
+    expect(result.content).toContain('learned to pick locks');
+    expect(result.content).toContain('## Timeline');
+    expect(result.content).toContain('### Chapter 1 — Opening');
+    expect(result.content).toContain('Day 1');
+    expect(result.content).toContain('### Open Plot Threads');
+    expect(result.content).toContain('the missing heir');
+    expect(result.content).toContain('## Locations');
+    expect(result.content).toContain('### The Docks');
+    expect(result.content).toContain('## World Rules');
+    expect(result.content).toContain('### Magic requires blood');
+    expect(result.content).toContain('## Items & Objects');
+    expect(result.content).toContain('### The Sealed Vault');
+  });
+
+  it('dedupes cross-project entities by lowercased name while merging sibling phases (ALP-1548 caveat)', async () => {
+    seedContext({
+      projectId: 'project-1', updatedAt: new Date().toISOString(), summaries: [],
+      entities: [
+        { name: 'Aria', type: 'character', aliases: [], description: 'Planning-phase description.', firstAppearance: 'project-1-step-1', lastSeen: 'project-1-step-1', attributes: {}, changes: [] },
+      ],
+    });
+    seedContext({
+      projectId: 'project-2', updatedAt: new Date().toISOString(), summaries: [],
+      entities: [
+        { name: 'aria', type: 'character', aliases: [], description: 'Production-phase description.', firstAppearance: 'project-2-step-1', lastSeen: 'project-2-step-1', attributes: {}, changes: [] },
+        { name: 'Kael', type: 'character', aliases: [], description: 'New in production.', firstAppearance: 'project-2-step-1', lastSeen: 'project-2-step-1', attributes: {}, changes: [] },
+      ],
+    });
+
+    const engine = fakeEngine([
+      project({ id: 'project-1', title: 'The Algorithm of Wanting' }),
+      project({ id: 'project-2', title: 'The Algorithm of Wanting' }),
+    ]);
+    const result = await service.compile(engine, contextEngine, 'project-2');
+
+    expect(result.mergedProjectIds.sort()).toEqual(['project-1', 'project-2']);
+    expect(result.counts.characters).toBe(2); // Aria deduped, Kael added
+    expect(result.content).toContain('Planning-phase description.'); // first-seen wins
+    expect(result.content).not.toContain('Production-phase description.');
+    expect(result.content).toContain('### Kael');
+  });
+});
+
+describe('BookBibleService.compile — empty-context path', () => {
+  it('produces a valid skeleton document when no context has been recorded yet', async () => {
+    const engine = fakeEngine([project({ id: 'project-9', title: 'Untouched Draft' })]);
+    const result = await service.compile(engine, contextEngine, 'project-9');
+
+    expect(result.counts).toEqual({
+      characters: 0, locations: 0, items: 0, events: 0, rules: 0, chapters: 0, planningNotes: 0,
+    });
+    expect(result.content).toContain('# Untouched Draft — Book Bible');
+    expect(result.content).toContain('_No characters tracked yet._');
+    expect(result.content).toContain('_No chapter timeline recorded yet._');
+    expect(result.content).toContain('_No locations tracked yet._');
+    expect(result.content).toContain('_No world rules tracked yet._');
+    expect(result.content).toContain('_No items tracked yet._');
+    expect(result.content).toContain('_None tracked yet._'); // open plot threads
+  });
+
+  it('throws a PROJECT_NOT_FOUND-coded error for an unknown project id', async () => {
+    const engine = fakeEngine([]);
+    await expect(service.compile(engine, contextEngine, 'missing')).rejects.toMatchObject({ code: 'PROJECT_NOT_FOUND' });
+  });
+});
+
+describe('BookBibleService.compile — folding in authored planning step files', () => {
+  it('folds character-profile, world-building, and premise step files into their sections when present', async () => {
+    seedContext({ projectId: 'project-5', updatedAt: new Date().toISOString(), summaries: [], entities: [] });
+
+    const projectDir = join(workspaceDir, 'workspace', 'projects', 'moonlit-heist');
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, 'project-5-step-2-character-profiles.md'),
+      '# Character profiles\n\nFull authored bios go here, richer than the extracted index.',
+      'utf-8',
+    );
+    writeFileSync(
+      join(projectDir, 'project-5-step-3-world-building-document.md'),
+      '# World-building document\n\nThe city runs on stolen moonlight.',
+      'utf-8',
+    );
+    writeFileSync(
+      join(projectDir, 'project-5-step-1-develop-premise.md'),
+      '# Develop premise\n\nA thief must steal back her own memories.',
+      'utf-8',
+    );
+
+    const engine = fakeEngine([
+      project({
+        id: 'project-5',
+        title: 'Moonlit Heist',
+        steps: [
+          { id: 'project-5-step-1', label: 'Develop premise', status: 'completed' },
+          { id: 'project-5-step-2', label: 'Character profiles', status: 'completed' },
+          { id: 'project-5-step-3', label: 'World-building document', status: 'completed' },
+          { id: 'project-5-step-4', label: 'Chapter-by-chapter outline', status: 'pending' },
+        ],
+      }),
+    ]);
+
+    const result = await service.compile(engine, contextEngine, 'project-5');
+
+    expect(result.counts.planningNotes).toBe(3);
+    expect(result.content).toContain('## Premise');
+    expect(result.content).toContain('A thief must steal back her own memories.');
+    expect(result.content).toContain('### Authored Character Notes');
+    expect(result.content).toContain('Full authored bios go here, richer than the extracted index.');
+    expect(result.content).toContain('### Authored World-Building Notes');
+    expect(result.content).toContain('The city runs on stolen moonlight.');
+  });
+
+  it('skips planning steps that are not completed or have no file on disk', async () => {
+    seedContext({ projectId: 'project-6', updatedAt: new Date().toISOString(), summaries: [], entities: [] });
+
+    const engine = fakeEngine([
+      project({
+        id: 'project-6',
+        title: 'No Notes Yet',
+        steps: [
+          { id: 'project-6-step-1', label: 'Character profiles', status: 'pending' }, // not completed, no file either
+        ],
+      }),
+    ]);
+
+    const result = await service.compile(engine, contextEngine, 'project-6');
+    expect(result.counts.planningNotes).toBe(0);
+    expect(result.content).not.toContain('### Authored Character Notes');
+  });
+});

--- a/gateway/src/services/book-bible.ts
+++ b/gateway/src/services/book-bible.ts
@@ -1,0 +1,328 @@
+/**
+ * AuthorAgent Book Bible Service
+ *
+ * Compiles a single canonical `book-bible.md` per book from data the
+ * ContextEngine already maintains (entities, chapter summaries, open plot
+ * threads) plus any authored planning-step files (character profiles,
+ * world-building doc, premise) when present. Deterministic assembly — no AI
+ * calls, no re-derivation of facts ContextEngine already tracked.
+ *
+ * Section structure mirrors skills/author/book-bible/SKILL.md: Characters,
+ * Timeline, Locations, World Rules, Items & Objects.
+ */
+
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import type { ContextEngine, EntityEntry, ChapterSummary } from './context-engine.js';
+
+export interface ProjectStepLike {
+  id: string;
+  label: string;
+  status: string;
+}
+
+export interface ProjectLike {
+  id: string;
+  title: string;
+  steps: ProjectStepLike[];
+}
+
+export interface ProjectEngineLike {
+  getProject(id: string): ProjectLike | undefined;
+  listProjects(): ProjectLike[];
+}
+
+export interface BookBibleCompileResult {
+  content: string;
+  projectId: string;
+  mergedProjectIds: string[];
+  counts: {
+    characters: number;
+    locations: number;
+    items: number;
+    events: number;
+    rules: number;
+    chapters: number;
+    planningNotes: number;
+  };
+}
+
+class ProjectNotFoundError extends Error {
+  code = 'PROJECT_NOT_FOUND';
+  constructor(projectId: string) {
+    super(`Project not found: ${projectId}`);
+  }
+}
+
+interface PlanningNote {
+  kind: 'character' | 'world' | 'premise';
+  label: string;
+  body: string;
+}
+
+// Matches the step labels shipped in project-templates.ts ("Character
+// profiles", "Character bible", "World-building document", "Develop
+// premise") without hardcoding the exact phase-specific wording, so future
+// label tweaks don't silently stop folding these in.
+const CHARACTER_STEP_RE = /character/i;
+const WORLD_STEP_RE = /world[\s-]?building/i;
+const PREMISE_STEP_RE = /premise/i;
+
+/** Same slug rule used throughout the codebase (documents.ts, projects.ts) for project directories. */
+export function projectSlug(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+}
+
+export class BookBibleService {
+  constructor(private baseDir: string) {}
+
+  /**
+   * Compile the book bible for `projectId`. If sibling project ids share the
+   * same title slug (e.g. a planning-phase project and a production-phase
+   * project for the same book — see ALP-1548), their entities are merged in
+   * too (deduped by lowercased name) so the bible isn't silently scoped to
+   * one pipeline phase.
+   */
+  async compile(
+    engine: ProjectEngineLike,
+    contextEngine: ContextEngine,
+    projectId: string,
+  ): Promise<BookBibleCompileResult> {
+    const project = engine.getProject(projectId);
+    if (!project) throw new ProjectNotFoundError(projectId);
+
+    const slug = projectSlug(project.title);
+    const siblingIds = engine
+      .listProjects()
+      .filter(p => projectSlug(p.title) === slug)
+      .map(p => p.id);
+    if (!siblingIds.includes(project.id)) siblingIds.push(project.id);
+
+    // loadContext populates ContextEngine's in-memory cache — the
+    // getEntitiesByType/getSummaries/getOpenPlotThreads reads below are pure
+    // in-memory and return [] until this has run.
+    for (const id of siblingIds) {
+      await contextEngine.loadContext(id);
+    }
+
+    const characters = this.mergeEntities(contextEngine, siblingIds, 'character');
+    const locations = this.mergeEntities(contextEngine, siblingIds, 'location');
+    const items = this.mergeEntities(contextEngine, siblingIds, 'item');
+    const events = this.mergeEntities(contextEngine, siblingIds, 'event');
+    const rules = this.mergeEntities(contextEngine, siblingIds, 'rule');
+
+    const summaries = siblingIds
+      .flatMap(id => contextEngine.getSummaries(id))
+      .sort((a, b) => a.chapterNumber - b.chapterNumber);
+
+    const openThreads = this.mergeOpenThreads(contextEngine, siblingIds);
+    const planningNotes = await this.collectPlanningNotes(engine, siblingIds);
+
+    const content = renderBookBible({
+      title: project.title,
+      mergedProjectIds: siblingIds,
+      characters,
+      locations,
+      items,
+      events,
+      rules,
+      summaries,
+      openThreads,
+      planningNotes,
+    });
+
+    return {
+      content,
+      projectId,
+      mergedProjectIds: siblingIds,
+      counts: {
+        characters: characters.length,
+        locations: locations.length,
+        items: items.length,
+        events: events.length,
+        rules: rules.length,
+        chapters: summaries.length,
+        planningNotes: planningNotes.length,
+      },
+    };
+  }
+
+  private mergeEntities(
+    contextEngine: ContextEngine,
+    projectIds: string[],
+    type: EntityEntry['type'],
+  ): EntityEntry[] {
+    const merged: EntityEntry[] = [];
+    const seen = new Set<string>();
+    for (const id of projectIds) {
+      for (const entity of contextEngine.getEntitiesByType(id, type)) {
+        const key = entity.name.toLowerCase().trim();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        merged.push(entity);
+      }
+    }
+    return merged;
+  }
+
+  private mergeOpenThreads(contextEngine: ContextEngine, projectIds: string[]): string[] {
+    const merged: string[] = [];
+    const seen = new Set<string>();
+    for (const id of projectIds) {
+      for (const thread of contextEngine.getOpenPlotThreads(id)) {
+        const key = thread.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        merged.push(thread);
+      }
+    }
+    return merged;
+  }
+
+  /** Authored planning-step files are richer than the prose-extracted index — fold them in when present. */
+  private async collectPlanningNotes(
+    engine: ProjectEngineLike,
+    projectIds: string[],
+  ): Promise<PlanningNote[]> {
+    const notes: PlanningNote[] = [];
+    for (const id of projectIds) {
+      const project = engine.getProject(id);
+      if (!project) continue;
+      const projectDir = join(this.baseDir, 'workspace', 'projects', projectSlug(project.title));
+
+      for (const step of project.steps || []) {
+        if (step.status !== 'completed') continue;
+        const kind: PlanningNote['kind'] | null = CHARACTER_STEP_RE.test(step.label)
+          ? 'character'
+          : WORLD_STEP_RE.test(step.label)
+            ? 'world'
+            : PREMISE_STEP_RE.test(step.label)
+              ? 'premise'
+              : null;
+        if (!kind) continue;
+
+        const filename = `${step.id}-${step.label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}.md`;
+        const filePath = join(projectDir, filename);
+        if (!existsSync(filePath)) continue;
+
+        try {
+          const raw = await readFile(filePath, 'utf-8');
+          const body = raw.replace(/^# .+\n\n/, '').trim();
+          if (body) notes.push({ kind, label: step.label, body });
+        } catch {
+          // Unreadable planning file — skip, don't fail the whole compile.
+        }
+      }
+    }
+    return notes;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════
+// Rendering
+// ═══════════════════════════════════════════════════════════
+
+interface RenderInput {
+  title: string;
+  mergedProjectIds: string[];
+  characters: EntityEntry[];
+  locations: EntityEntry[];
+  items: EntityEntry[];
+  events: EntityEntry[];
+  rules: EntityEntry[];
+  summaries: ChapterSummary[];
+  openThreads: string[];
+  planningNotes: PlanningNote[];
+}
+
+function renderBookBible(d: RenderInput): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${d.title} — Book Bible`, '');
+  lines.push(
+    d.mergedProjectIds.length > 1
+      ? `_Merged from ${d.mergedProjectIds.length} pipeline phases: ${d.mergedProjectIds.join(', ')}._`
+      : `_Compiled from ${d.mergedProjectIds[0]}._`,
+    '',
+  );
+
+  const premiseNotes = d.planningNotes.filter(n => n.kind === 'premise');
+  if (premiseNotes.length > 0) {
+    lines.push('## Premise', '');
+    for (const n of premiseNotes) lines.push(n.body, '');
+  }
+
+  lines.push('## Characters', '');
+  lines.push(...renderEntitySection(d.characters, 'No characters tracked yet.'));
+  const characterNotes = d.planningNotes.filter(n => n.kind === 'character');
+  if (characterNotes.length > 0) {
+    lines.push('### Authored Character Notes', '');
+    for (const n of characterNotes) lines.push(`**${n.label}**`, '', n.body, '');
+  }
+
+  lines.push('## Timeline', '');
+  if (d.summaries.length === 0) {
+    lines.push('_No chapter timeline recorded yet._', '');
+  } else {
+    for (const s of d.summaries) {
+      lines.push(`### Chapter ${s.chapterNumber} — ${s.title}`);
+      if (s.timelineMarker) lines.push(`_${s.timelineMarker}_`);
+      lines.push('', s.endingState || s.summary || '', '');
+    }
+  }
+  if (d.events.length > 0) {
+    lines.push('### Key Events', '');
+    for (const e of d.events) lines.push(renderEntity(e));
+  }
+  lines.push('### Open Plot Threads', '');
+  if (d.openThreads.length === 0) {
+    lines.push('_None tracked yet._', '');
+  } else {
+    for (const t of d.openThreads) lines.push(`- ${t}`);
+    lines.push('');
+  }
+
+  lines.push('## Locations', '');
+  lines.push(...renderEntitySection(d.locations, 'No locations tracked yet.'));
+
+  lines.push('## World Rules', '');
+  lines.push(...renderEntitySection(d.rules, 'No world rules tracked yet.'));
+  const worldNotes = d.planningNotes.filter(n => n.kind === 'world');
+  if (worldNotes.length > 0) {
+    lines.push('### Authored World-Building Notes', '');
+    for (const n of worldNotes) lines.push(`**${n.label}**`, '', n.body, '');
+  }
+
+  lines.push('## Items & Objects', '');
+  lines.push(...renderEntitySection(d.items, 'No items tracked yet.'));
+
+  return lines
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd() + '\n';
+}
+
+function renderEntitySection(entities: EntityEntry[], emptyMessage: string): string[] {
+  if (entities.length === 0) return [`_${emptyMessage}_`, ''];
+  return entities.map(e => renderEntity(e));
+}
+
+function renderEntity(e: EntityEntry): string {
+  const parts: string[] = [];
+  const aliasStr = e.aliases && e.aliases.length ? ` (${e.aliases.join(', ')})` : '';
+  parts.push(`### ${e.name}${aliasStr}`);
+  if (e.description) parts.push(e.description);
+
+  const attrs = Object.entries(e.attributes || {});
+  if (attrs.length > 0) {
+    parts.push(attrs.map(([k, v]) => `- **${k}:** ${v}`).join('\n'));
+  }
+
+  if (e.changes && e.changes.length > 0) {
+    parts.push('**Changes:**\n' + e.changes.map(c => `- ${c.description} (${c.chapterId})`).join('\n'));
+  }
+
+  parts.push(`_First appearance: ${e.firstAppearance} · Last seen: ${e.lastSeen}_`);
+  return parts.join('\n\n') + '\n';
+}

--- a/gateway/src/services/dependency-graph.test.ts
+++ b/gateway/src/services/dependency-graph.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { computeTransitiveDependents, markDependentsDirty } from './dependency-graph.js';
+import type { ProjectStep } from './project-templates.js';
+
+function makeStep(overrides: Partial<ProjectStep> = {}): ProjectStep {
+  return {
+    id: 's1',
+    label: 'Step',
+    taskType: 'general',
+    prompt: 'do it',
+    status: 'completed',
+    ...overrides,
+  };
+}
+
+describe('computeTransitiveDependents', () => {
+  it('follows a chain of dependsOn edges transitively', () => {
+    // A <- B <- C <- D (B depends on A, C depends on B, D depends on C)
+    const steps = [
+      makeStep({ id: 'A' }),
+      makeStep({ id: 'B', dependsOn: ['A'] }),
+      makeStep({ id: 'C', dependsOn: ['B'] }),
+      makeStep({ id: 'D', dependsOn: ['C'] }),
+    ];
+
+    expect(computeTransitiveDependents(steps, 'A')).toEqual(new Set(['B', 'C', 'D']));
+    expect(computeTransitiveDependents(steps, 'C')).toEqual(new Set(['D']));
+    expect(computeTransitiveDependents(steps, 'D')).toEqual(new Set());
+  });
+
+  it('handles diamond dependencies without duplicating a dependent', () => {
+    // A <- B, A <- C, B <- D, C <- D
+    const steps = [
+      makeStep({ id: 'A' }),
+      makeStep({ id: 'B', dependsOn: ['A'] }),
+      makeStep({ id: 'C', dependsOn: ['A'] }),
+      makeStep({ id: 'D', dependsOn: ['B', 'C'] }),
+    ];
+
+    expect(computeTransitiveDependents(steps, 'A')).toEqual(new Set(['B', 'C', 'D']));
+  });
+
+  it('returns an empty set for a step with no dependents', () => {
+    const steps = [makeStep({ id: 'A' }), makeStep({ id: 'B', dependsOn: ['A'] })];
+    expect(computeTransitiveDependents(steps, 'B')).toEqual(new Set());
+  });
+
+  it('is defensive against cyclic-looking dependsOn input — terminates, excludes self', () => {
+    // A -> B -> C -> A (a cycle that should never occur in practice)
+    const steps = [
+      makeStep({ id: 'A', dependsOn: ['C'] }),
+      makeStep({ id: 'B', dependsOn: ['A'] }),
+      makeStep({ id: 'C', dependsOn: ['B'] }),
+    ];
+
+    const result = computeTransitiveDependents(steps, 'A');
+    expect(result).toEqual(new Set(['B', 'C']));
+    expect(result.has('A')).toBe(false);
+  });
+
+  it('is defensive against a step depending on itself', () => {
+    const steps = [makeStep({ id: 'A', dependsOn: ['A'] })];
+    const result = computeTransitiveDependents(steps, 'A');
+    expect(result.has('A')).toBe(false);
+  });
+});
+
+describe('markDependentsDirty', () => {
+  it('marks every transitively dependent completed step dirty with the correct cause', () => {
+    const steps = [
+      makeStep({ id: 'A', status: 'completed' }),
+      makeStep({ id: 'B', dependsOn: ['A'], status: 'completed' }),
+      makeStep({ id: 'C', dependsOn: ['B'], status: 'completed' }),
+    ];
+
+    const now = '2026-08-02T00:00:00.000Z';
+    const marked = markDependentsDirty(steps, 'A', 3, 4, now);
+
+    expect(marked.sort()).toEqual(['B', 'C']);
+
+    const [, b, c] = steps;
+    expect(b.dirty).toEqual({
+      causeStepId: 'A',
+      causeVersionFrom: 3,
+      causeVersionTo: 4,
+      markedAt: now,
+    });
+    expect(c.dirty).toEqual({
+      causeStepId: 'A',
+      causeVersionFrom: 3,
+      causeVersionTo: 4,
+      markedAt: now,
+    });
+    // severity is left undefined for M4 to fill in.
+    expect(b.dirty?.severity).toBeUndefined();
+  });
+
+  it('leaves status untouched — dirty is orthogonal to status', () => {
+    const steps = [
+      makeStep({ id: 'A', status: 'completed' }),
+      makeStep({ id: 'B', dependsOn: ['A'], status: 'completed' }),
+    ];
+
+    markDependentsDirty(steps, 'A', 1, 2);
+
+    expect(steps[1].status).toBe('completed');
+    expect(steps[1].dirty).toBeDefined();
+  });
+
+  it('only marks dependents whose status is completed', () => {
+    const steps = [
+      makeStep({ id: 'A', status: 'completed' }),
+      makeStep({ id: 'B', dependsOn: ['A'], status: 'completed' }),
+      makeStep({ id: 'C', dependsOn: ['A'], status: 'pending' }),
+      makeStep({ id: 'D', dependsOn: ['A'], status: 'awaiting_review' }),
+      makeStep({ id: 'E', dependsOn: ['A'], status: 'skipped' }),
+      makeStep({ id: 'F', dependsOn: ['A'], status: 'failed' }),
+      makeStep({ id: 'G', dependsOn: ['A'], status: 'active' }),
+    ];
+
+    const marked = markDependentsDirty(steps, 'A', 1, 2);
+
+    expect(marked).toEqual(['B']);
+    for (const id of ['C', 'D', 'E', 'F', 'G']) {
+      expect(steps.find((s) => s.id === id)!.dirty).toBeUndefined();
+    }
+  });
+
+  it('returns an empty array and mutates nothing when the cause step has no dependents', () => {
+    const steps = [makeStep({ id: 'A', status: 'completed' })];
+    const marked = markDependentsDirty(steps, 'A', 1, 2);
+    expect(marked).toEqual([]);
+  });
+
+  it('terminates and marks correctly even against cyclic-looking dependsOn input', () => {
+    // A -> B -> C -> A, all completed. Marking from A should not hang, and
+    // should mark B and C (transitively dependent) without marking A itself.
+    const steps = [
+      makeStep({ id: 'A', dependsOn: ['C'], status: 'completed' }),
+      makeStep({ id: 'B', dependsOn: ['A'], status: 'completed' }),
+      makeStep({ id: 'C', dependsOn: ['B'], status: 'completed' }),
+    ];
+
+    const marked = markDependentsDirty(steps, 'A', 1, 2);
+
+    expect(marked.sort()).toEqual(['B', 'C']);
+    expect(steps[0].dirty).toBeUndefined();
+  });
+
+  it('overwrites a stale dirty marker with the newest cause when marked again', () => {
+    const steps = [
+      makeStep({ id: 'A', status: 'completed' }),
+      makeStep({ id: 'B', dependsOn: ['A'], status: 'completed' }),
+    ];
+
+    markDependentsDirty(steps, 'A', 1, 2, '2026-08-01T00:00:00.000Z');
+    markDependentsDirty(steps, 'A', 2, 3, '2026-08-02T00:00:00.000Z');
+
+    expect(steps[1].dirty).toEqual({
+      causeStepId: 'A',
+      causeVersionFrom: 2,
+      causeVersionTo: 3,
+      markedAt: '2026-08-02T00:00:00.000Z',
+    });
+  });
+});

--- a/gateway/src/services/dependency-graph.ts
+++ b/gateway/src/services/dependency-graph.ts
@@ -1,0 +1,105 @@
+/**
+ * Dirty Dependency Graph Service
+ *
+ * Computes the transitive closure of a project's step dependency graph
+ * (edges are step.dependsOn, populated by deriveDependencies() in
+ * project-templates.ts — no new graph data is created here) and marks every
+ * completed step that transitively depends on a changed step `dirty`.
+ *
+ * Triggered when an already-approved step gains a new version: every
+ * completed step downstream of it (directly or transitively) is stamped with
+ * a DirtyMarker recording the cause and version range. `dirty` never touches
+ * `status` — see DirtyMarker in project-templates.ts.
+ */
+
+import type { ProjectStep, DirtyMarker } from './project-templates.js';
+import { logger } from './logger.js';
+
+const log = logger.child('[dependency-graph]');
+
+/**
+ * Build a reverse adjacency map: stepId -> ids of the steps that list it in
+ * their own `dependsOn` (its direct dependents).
+ */
+function buildDependentsIndex(steps: ProjectStep[]): Map<string, string[]> {
+  const dependents = new Map<string, string[]>();
+  for (const step of steps) {
+    if (!Array.isArray(step.dependsOn)) continue;
+    for (const upstreamId of step.dependsOn) {
+      const list = dependents.get(upstreamId);
+      if (list) list.push(step.id);
+      else dependents.set(upstreamId, [step.id]);
+    }
+  }
+  return dependents;
+}
+
+/**
+ * Compute every step id that transitively depends on `stepId` (directly, or
+ * through any chain of dependsOn edges). Guarded with a visited set so
+ * cyclic-looking `dependsOn` input terminates instead of hanging — cycles
+ * should never occur in practice (deriveDependencies is acyclic by
+ * construction) but this must not hang or crash if one somehow appears.
+ */
+export function computeTransitiveDependents(steps: ProjectStep[], stepId: string): Set<string> {
+  const dependentsIndex = buildDependentsIndex(steps);
+  const visited = new Set<string>();
+  const queue: string[] = [stepId];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const directDependents = dependentsIndex.get(current) ?? [];
+    for (const dependentId of directDependents) {
+      if (visited.has(dependentId)) continue; // cycle guard
+      visited.add(dependentId);
+      queue.push(dependentId);
+    }
+  }
+
+  visited.delete(stepId); // a step is never its own dependent, even in a cycle
+  return visited;
+}
+
+/**
+ * Mark every completed step that transitively depends on `causeStepId`
+ * dirty, mutating `steps` in place. Returns the ids of the steps actually
+ * marked.
+ *
+ * Only `completed` steps are marked — pending/active/awaiting_review/
+ * skipped/failed steps aren't touched; they'll pick up the new upstream
+ * content the next time they run or get reviewed. `dirty` is orthogonal to
+ * `status` (see DirtyMarker) — marking a step dirty never changes its status.
+ */
+export function markDependentsDirty(
+  steps: ProjectStep[],
+  causeStepId: string,
+  causeVersionFrom: number,
+  causeVersionTo: number,
+  now: string = new Date().toISOString(),
+): string[] {
+  const dependentIds = computeTransitiveDependents(steps, causeStepId);
+  if (dependentIds.size === 0) return [];
+
+  const stepsById = new Map(steps.map((s) => [s.id, s]));
+  const marked: string[] = [];
+
+  for (const id of dependentIds) {
+    const step = stepsById.get(id);
+    if (!step || step.status !== 'completed') continue;
+
+    const marker: DirtyMarker = {
+      causeStepId,
+      causeVersionFrom,
+      causeVersionTo,
+      markedAt: now,
+    };
+    step.dirty = marker;
+    marked.push(id);
+  }
+
+  if (marked.length > 0) {
+    log.debug(`Marked ${marked.length} step(s) dirty (cause: ${causeStepId} v${causeVersionFrom}->v${causeVersionTo})`);
+  }
+
+  return marked;
+}

--- a/gateway/src/services/doc-versions.test.ts
+++ b/gateway/src/services/doc-versions.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, writeFile, readFile, rm } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { DocVersionService } from './doc-versions.js';
+
+describe('DocVersionService', () => {
+  let tempDir: string;
+  let service: DocVersionService;
+  const TEST_STEP_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `doc-versions-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+    service = new DocVersionService();
+  });
+
+  afterEach(async () => {
+    if (existsSync(tempDir)) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('appends a version and returns the version number', async () => {
+    const stepFilePath = join(tempDir, 'abc123-step-label.md');
+    const content = 'Version 1 content';
+
+    const v = await service.appendVersion(stepFilePath, content);
+
+    expect(v).toBe(1);
+    const versionFile = join(tempDir, '.versions', 'abc123', 'v1.md');
+    expect(existsSync(versionFile)).toBe(true);
+    const stored = await readFile(versionFile, 'utf-8');
+    expect(stored).toBe(content);
+  });
+
+  it('increments version numbers correctly', async () => {
+    const stepFilePath = join(tempDir, 'abc123-step-label.md');
+
+    const v1 = await service.appendVersion(stepFilePath, 'V1');
+    const v2 = await service.appendVersion(stepFilePath, 'V2');
+    const v3 = await service.appendVersion(stepFilePath, 'V3');
+
+    expect(v1).toBe(1);
+    expect(v2).toBe(2);
+    expect(v3).toBe(3);
+  });
+
+  it('stores version metadata in index', async () => {
+    const stepFilePath = join(tempDir, 'abc123-step-label.md');
+
+    const v = await service.appendVersion(stepFilePath, 'Test content', 'agent', 'Test note');
+    const versions = await service.getVersions(stepFilePath);
+
+    expect(versions).toHaveLength(1);
+    expect(versions[0]).toMatchObject({
+      v: 1,
+      author: 'agent',
+      note: 'Test note',
+    });
+    expect(versions[0].ts).toBeDefined();
+    expect(versions[0].sha256).toBeDefined();
+  });
+
+  it('handles lazy migration from pre-existing file', async () => {
+    const stepFilePath = join(tempDir, 'xyz789-existing-step.md');
+    const existingContent = 'Pre-fork content';
+
+    // Create a pre-existing step file
+    await writeFile(stepFilePath, existingContent, 'utf-8');
+
+    // Request versions — should trigger lazy migration
+    const versions = await service.getVersions(stepFilePath);
+
+    expect(versions).toHaveLength(1);
+    expect(versions[0]).toMatchObject({
+      v: 1,
+      author: 'agent',
+      note: 'Seeded from pre-existing step file',
+    });
+
+    const v1Content = await service.getVersionContent(stepFilePath, 1);
+    expect(v1Content).toBe(existingContent);
+  });
+
+  it('restores an old version by creating a new version', async () => {
+    const stepFilePath = join(tempDir, 'def456-restore-test.md');
+
+    const v1 = await service.appendVersion(stepFilePath, 'Version 1');
+    const v2 = await service.appendVersion(stepFilePath, 'Version 2');
+    const v3 = await service.restoreVersion(stepFilePath, 1);
+
+    expect(v3).toBe(3);
+
+    const versions = await service.getVersions(stepFilePath);
+    expect(versions).toHaveLength(3);
+
+    const restoredContent = await service.getVersionContent(stepFilePath, 3);
+    expect(restoredContent).toBe('Version 1');
+
+    // Verify metadata indicates it was a restore
+    expect(versions[2]).toMatchObject({
+      author: 'agent-patch',
+      note: 'Restored from v1',
+      parentV: 2,
+    });
+  });
+
+  it('retrieves specific version content', async () => {
+    const stepFilePath = join(tempDir, 'ghi789-retrieve-test.md');
+
+    await service.appendVersion(stepFilePath, 'Content A');
+    await service.appendVersion(stepFilePath, 'Content B');
+    await service.appendVersion(stepFilePath, 'Content C');
+
+    const v1 = await service.getVersionContent(stepFilePath, 1);
+    const v2 = await service.getVersionContent(stepFilePath, 2);
+    const v3 = await service.getVersionContent(stepFilePath, 3);
+
+    expect(v1).toBe('Content A');
+    expect(v2).toBe('Content B');
+    expect(v3).toBe('Content C');
+  });
+
+  it('returns null for non-existent version', async () => {
+    const stepFilePath = join(tempDir, 'jkl012-nonexist-test.md');
+
+    await service.appendVersion(stepFilePath, 'Content');
+    const nonExistent = await service.getVersionContent(stepFilePath, 999);
+
+    expect(nonExistent).toBeNull();
+  });
+
+  it('tracks current version correctly', async () => {
+    const stepFilePath = join(tempDir, 'mno345-current-test.md');
+
+    let current = await service.getCurrentVersion(stepFilePath);
+    expect(current).toBe(0);
+
+    await service.appendVersion(stepFilePath, 'V1');
+    current = await service.getCurrentVersion(stepFilePath);
+    expect(current).toBe(1);
+
+    await service.appendVersion(stepFilePath, 'V2');
+    current = await service.getCurrentVersion(stepFilePath);
+    expect(current).toBe(2);
+  });
+
+  it('computes SHA256 hashes correctly', async () => {
+    const stepFilePath = join(tempDir, 'pqr678-hash-test.md');
+
+    await service.appendVersion(stepFilePath, 'Content A');
+    await service.appendVersion(stepFilePath, 'Content B');
+    await service.appendVersion(stepFilePath, 'Content A'); // Same as v1
+
+    const versions = await service.getVersions(stepFilePath);
+
+    expect(versions[0].sha256).toBe(versions[2].sha256); // Same content, same hash
+    expect(versions[0].sha256).not.toBe(versions[1].sha256); // Different content, different hash
+  });
+
+  it('version history is immutable', async () => {
+    const stepFilePath = join(tempDir, 'stu901-immutable-test.md');
+
+    const v1 = await service.appendVersion(stepFilePath, 'Original');
+    const v1Content = await service.getVersionContent(stepFilePath, 1);
+
+    // Append new versions
+    await service.appendVersion(stepFilePath, 'V2');
+    await service.appendVersion(stepFilePath, 'V3');
+
+    // Original version should remain unchanged
+    const v1ContentAfter = await service.getVersionContent(stepFilePath, 1);
+    expect(v1ContentAfter).toBe(v1Content);
+    expect(v1ContentAfter).toBe('Original');
+  });
+
+  it('survives a regenerate (version history persists)', async () => {
+    const stepFilePath = join(tempDir, 'vwx234-regenerate-test.md');
+
+    // Simulate first generation
+    await service.appendVersion(stepFilePath, 'First generation');
+
+    // Simulate a regenerate (new version appended)
+    const v2 = await service.appendVersion(stepFilePath, 'Regenerated version');
+
+    // History should still be intact
+    const versions = await service.getVersions(stepFilePath);
+    expect(versions).toHaveLength(2);
+    expect(versions[0]).toMatchObject({ v: 1, author: 'agent' });
+    expect(versions[1]).toMatchObject({ v: 2, author: 'agent' });
+  });
+});

--- a/gateway/src/services/doc-versions.test.ts
+++ b/gateway/src/services/doc-versions.test.ts
@@ -6,41 +6,38 @@ import { tmpdir } from 'os';
 import { DocVersionService } from './doc-versions.js';
 
 describe('DocVersionService', () => {
-  let tempDir: string;
+  let projectDir: string;
   let service: DocVersionService;
-  const TEST_STEP_ID = '550e8400-e29b-41d4-a716-446655440000';
+  const STEP_ID = '550e8400-e29b-41d4-a716-446655440000';
 
   beforeEach(async () => {
-    tempDir = join(tmpdir(), `doc-versions-test-${Date.now()}`);
-    await mkdir(tempDir, { recursive: true });
+    projectDir = join(tmpdir(), `doc-versions-test-${Date.now()}`);
+    await mkdir(projectDir, { recursive: true });
     service = new DocVersionService();
   });
 
   afterEach(async () => {
-    if (existsSync(tempDir)) {
-      await rm(tempDir, { recursive: true, force: true });
+    if (existsSync(projectDir)) {
+      await rm(projectDir, { recursive: true, force: true });
     }
   });
 
   it('appends a version and returns the version number', async () => {
-    const stepFilePath = join(tempDir, 'abc123-step-label.md');
     const content = 'Version 1 content';
 
-    const v = await service.appendVersion(stepFilePath, content);
+    const v = await service.appendVersion(projectDir, STEP_ID, content);
 
     expect(v).toBe(1);
-    const versionFile = join(tempDir, '.versions', 'abc123', 'v1.md');
+    const versionFile = join(projectDir, '.versions', STEP_ID, 'v1.md');
     expect(existsSync(versionFile)).toBe(true);
     const stored = await readFile(versionFile, 'utf-8');
     expect(stored).toBe(content);
   });
 
   it('increments version numbers correctly', async () => {
-    const stepFilePath = join(tempDir, 'abc123-step-label.md');
-
-    const v1 = await service.appendVersion(stepFilePath, 'V1');
-    const v2 = await service.appendVersion(stepFilePath, 'V2');
-    const v3 = await service.appendVersion(stepFilePath, 'V3');
+    const v1 = await service.appendVersion(projectDir, STEP_ID, 'V1');
+    const v2 = await service.appendVersion(projectDir, STEP_ID, 'V2');
+    const v3 = await service.appendVersion(projectDir, STEP_ID, 'V3');
 
     expect(v1).toBe(1);
     expect(v2).toBe(2);
@@ -48,10 +45,8 @@ describe('DocVersionService', () => {
   });
 
   it('stores version metadata in index', async () => {
-    const stepFilePath = join(tempDir, 'abc123-step-label.md');
-
-    const v = await service.appendVersion(stepFilePath, 'Test content', 'agent', 'Test note');
-    const versions = await service.getVersions(stepFilePath);
+    const v = await service.appendVersion(projectDir, STEP_ID, 'Test content', 'agent', 'Test note');
+    const versions = await service.getVersions(projectDir, STEP_ID);
 
     expect(versions).toHaveLength(1);
     expect(versions[0]).toMatchObject({
@@ -64,14 +59,15 @@ describe('DocVersionService', () => {
   });
 
   it('handles lazy migration from pre-existing file', async () => {
-    const stepFilePath = join(tempDir, 'xyz789-existing-step.md');
+    const canonicalPath = join(projectDir, `${STEP_ID}-chapter-one.md`);
     const existingContent = 'Pre-fork content';
 
     // Create a pre-existing step file
-    await writeFile(stepFilePath, existingContent, 'utf-8');
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(canonicalPath, existingContent, 'utf-8');
 
-    // Request versions — should trigger lazy migration
-    const versions = await service.getVersions(stepFilePath);
+    // Request versions with canonicalPath — should trigger lazy migration
+    const versions = await service.getVersions(projectDir, STEP_ID, canonicalPath);
 
     expect(versions).toHaveLength(1);
     expect(versions[0]).toMatchObject({
@@ -80,23 +76,21 @@ describe('DocVersionService', () => {
       note: 'Seeded from pre-existing step file',
     });
 
-    const v1Content = await service.getVersionContent(stepFilePath, 1);
+    const v1Content = await service.getVersionContent(projectDir, STEP_ID, 1);
     expect(v1Content).toBe(existingContent);
   });
 
   it('restores an old version by creating a new version', async () => {
-    const stepFilePath = join(tempDir, 'def456-restore-test.md');
-
-    const v1 = await service.appendVersion(stepFilePath, 'Version 1');
-    const v2 = await service.appendVersion(stepFilePath, 'Version 2');
-    const v3 = await service.restoreVersion(stepFilePath, 1);
+    const v1 = await service.appendVersion(projectDir, STEP_ID, 'Version 1');
+    const v2 = await service.appendVersion(projectDir, STEP_ID, 'Version 2');
+    const v3 = await service.restoreVersion(projectDir, STEP_ID, 1);
 
     expect(v3).toBe(3);
 
-    const versions = await service.getVersions(stepFilePath);
+    const versions = await service.getVersions(projectDir, STEP_ID);
     expect(versions).toHaveLength(3);
 
-    const restoredContent = await service.getVersionContent(stepFilePath, 3);
+    const restoredContent = await service.getVersionContent(projectDir, STEP_ID, 3);
     expect(restoredContent).toBe('Version 1');
 
     // Verify metadata indicates it was a restore
@@ -108,15 +102,13 @@ describe('DocVersionService', () => {
   });
 
   it('retrieves specific version content', async () => {
-    const stepFilePath = join(tempDir, 'ghi789-retrieve-test.md');
+    await service.appendVersion(projectDir, STEP_ID, 'Content A');
+    await service.appendVersion(projectDir, STEP_ID, 'Content B');
+    await service.appendVersion(projectDir, STEP_ID, 'Content C');
 
-    await service.appendVersion(stepFilePath, 'Content A');
-    await service.appendVersion(stepFilePath, 'Content B');
-    await service.appendVersion(stepFilePath, 'Content C');
-
-    const v1 = await service.getVersionContent(stepFilePath, 1);
-    const v2 = await service.getVersionContent(stepFilePath, 2);
-    const v3 = await service.getVersionContent(stepFilePath, 3);
+    const v1 = await service.getVersionContent(projectDir, STEP_ID, 1);
+    const v2 = await service.getVersionContent(projectDir, STEP_ID, 2);
+    const v3 = await service.getVersionContent(projectDir, STEP_ID, 3);
 
     expect(v1).toBe('Content A');
     expect(v2).toBe('Content B');
@@ -124,69 +116,59 @@ describe('DocVersionService', () => {
   });
 
   it('returns null for non-existent version', async () => {
-    const stepFilePath = join(tempDir, 'jkl012-nonexist-test.md');
-
-    await service.appendVersion(stepFilePath, 'Content');
-    const nonExistent = await service.getVersionContent(stepFilePath, 999);
+    await service.appendVersion(projectDir, STEP_ID, 'Content');
+    const nonExistent = await service.getVersionContent(projectDir, STEP_ID, 999);
 
     expect(nonExistent).toBeNull();
   });
 
   it('tracks current version correctly', async () => {
-    const stepFilePath = join(tempDir, 'mno345-current-test.md');
-
-    let current = await service.getCurrentVersion(stepFilePath);
+    let current = await service.getCurrentVersion(projectDir, STEP_ID);
     expect(current).toBe(0);
 
-    await service.appendVersion(stepFilePath, 'V1');
-    current = await service.getCurrentVersion(stepFilePath);
+    await service.appendVersion(projectDir, STEP_ID, 'V1');
+    current = await service.getCurrentVersion(projectDir, STEP_ID);
     expect(current).toBe(1);
 
-    await service.appendVersion(stepFilePath, 'V2');
-    current = await service.getCurrentVersion(stepFilePath);
+    await service.appendVersion(projectDir, STEP_ID, 'V2');
+    current = await service.getCurrentVersion(projectDir, STEP_ID);
     expect(current).toBe(2);
   });
 
   it('computes SHA256 hashes correctly', async () => {
-    const stepFilePath = join(tempDir, 'pqr678-hash-test.md');
+    await service.appendVersion(projectDir, STEP_ID, 'Content A');
+    await service.appendVersion(projectDir, STEP_ID, 'Content B');
+    await service.appendVersion(projectDir, STEP_ID, 'Content A'); // Same as v1
 
-    await service.appendVersion(stepFilePath, 'Content A');
-    await service.appendVersion(stepFilePath, 'Content B');
-    await service.appendVersion(stepFilePath, 'Content A'); // Same as v1
-
-    const versions = await service.getVersions(stepFilePath);
+    const versions = await service.getVersions(projectDir, STEP_ID);
 
     expect(versions[0].sha256).toBe(versions[2].sha256); // Same content, same hash
     expect(versions[0].sha256).not.toBe(versions[1].sha256); // Different content, different hash
   });
 
   it('version history is immutable', async () => {
-    const stepFilePath = join(tempDir, 'stu901-immutable-test.md');
-
-    const v1 = await service.appendVersion(stepFilePath, 'Original');
-    const v1Content = await service.getVersionContent(stepFilePath, 1);
+    const v1 = await service.appendVersion(projectDir, STEP_ID, 'Original');
+    const v1Content = await service.getVersionContent(projectDir, STEP_ID, 1);
 
     // Append new versions
-    await service.appendVersion(stepFilePath, 'V2');
-    await service.appendVersion(stepFilePath, 'V3');
+    await service.appendVersion(projectDir, STEP_ID, 'V2');
+    await service.appendVersion(projectDir, STEP_ID, 'V3');
 
     // Original version should remain unchanged
-    const v1ContentAfter = await service.getVersionContent(stepFilePath, 1);
+    const v1ContentAfter = await service.getVersionContent(projectDir, STEP_ID, 1);
     expect(v1ContentAfter).toBe(v1Content);
     expect(v1ContentAfter).toBe('Original');
   });
 
   it('survives a regenerate (version history persists)', async () => {
-    const stepFilePath = join(tempDir, 'vwx234-regenerate-test.md');
-
     // Simulate first generation
-    await service.appendVersion(stepFilePath, 'First generation');
+    await service.appendVersion(projectDir, STEP_ID, 'First generation');
 
     // Simulate a regenerate (new version appended)
-    const v2 = await service.appendVersion(stepFilePath, 'Regenerated version');
+    const v2 = await service.appendVersion(projectDir, STEP_ID, 'Regenerated version');
 
     // History should still be intact
-    const versions = await service.getVersions(stepFilePath);
+    const versions = await service.getVersions(projectDir, STEP_ID);
     expect(versions).toHaveLength(2);
     expect(versions[0]).toMatchObject({ v: 1, author: 'agent' });
     expect(versions[1]).toMatchObject({ v: 2, author: 'agent' });

--- a/gateway/src/services/doc-versions.ts
+++ b/gateway/src/services/doc-versions.ts
@@ -5,276 +5,149 @@
  * - workspace/projects/<slug>/.versions/<stepId>/
  *   - v1.md, v2.md, ... (immutable version files)
  *   - index.json (metadata: entries with v, author, ts, note, parentV, sha256)
- * - workspace/projects/<slug>/<stepId>-<label>.md (canonical/current pointer)
+ * - workspace/projects/<slug>/<stepId>-<label>.md (canonical/current pointer,
+ *   unchanged so compile/export-docx/epub-export/ContextEngine keep working)
  *
  * Migration is lazy: first time a pre-existing step's history is requested,
- * seed v1 from the current .md file without downtime.
+ * seed v1 from the current .md file — no batch migration, no downtime.
  *
  * Versioning is immutable. Restoring an old version creates a NEW version
  * with that content — it never rewrites history.
+ *
+ * Callers pass `stepId` explicitly rather than parsing it back out of the
+ * canonical `<stepId>-<label>.md` filename — the label is free-text (itself
+ * dash-slugified), so the split point between id and label can't be recovered
+ * reliably once both are joined by dashes (e.g. step id `12-step-3` plus label
+ * `write-chapter-3` collapse into one ambiguous dash-separated string).
  */
 
-import { mkdir, writeFile, readFile, readdir } from 'fs/promises';
+import { mkdir, writeFile, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
-import { join, dirname } from 'path';
+import { join } from 'path';
 import { createHash } from 'crypto';
 import { logger } from './logger.js';
 
 const log = logger.child('[doc-versions]');
 
-interface VersionEntry {
+export type VersionAuthor = 'agent' | 'user' | 'agent-patch';
+
+export interface VersionEntry {
   v: number;
-  author: 'agent' | 'user' | 'agent-patch';
+  author: VersionAuthor;
   ts: number;
   note?: string;
   parentV?: number;
   sha256: string;
 }
 
-interface VersionIndex {
-  entries: VersionEntry[];
-  currentV: number;
-}
-
 export class DocVersionService {
   /**
-   * Append a new version for a step. Returns the version number.
-   * Author: 'agent' for AI-generated, 'user' for manual edits, 'agent-patch' for auto-corrections.
+   * Append a new immutable version for a step and return its version number.
    */
   async appendVersion(
-    stepFilePath: string,
+    projectDir: string,
+    stepId: string,
     content: string,
-    author: 'agent' | 'user' | 'agent-patch' = 'agent',
-    note?: string
+    author: VersionAuthor = 'agent',
+    note?: string,
   ): Promise<number> {
-    try {
-      const versionDir = this.getVersionDir(stepFilePath);
-      const indexPath = join(versionDir, 'index.json');
+    const versionDir = this.getVersionDir(projectDir, stepId);
+    await mkdir(versionDir, { recursive: true });
 
-      // Ensure version directory exists
-      await mkdir(versionDir, { recursive: true });
+    const entries = await this.readIndex(versionDir);
+    const parentV = entries.length ? entries[entries.length - 1].v : undefined;
+    const v = (parentV ?? 0) + 1;
 
-      // Read or create the index
-      let index: VersionIndex;
-      if (existsSync(indexPath)) {
-        const indexData = await readFile(indexPath, 'utf-8');
-        index = JSON.parse(indexData);
-      } else {
-        // Check if this is a pre-existing step (needs lazy migration)
-        if (existsSync(stepFilePath)) {
-          await this.seedV1FromExisting(stepFilePath, versionDir, indexPath);
-          const indexData = await readFile(indexPath, 'utf-8');
-          index = JSON.parse(indexData);
-        } else {
-          index = { entries: [], currentV: 0 };
-        }
-      }
+    await writeFile(join(versionDir, `v${v}.md`), content, 'utf-8');
 
-      // Compute next version number and SHA256
-      const nextV = index.currentV + 1;
-      const sha = this.hashContent(content);
-      const parentV = index.currentV > 0 ? index.currentV : undefined;
+    entries.push({
+      v,
+      author,
+      ts: Date.now(),
+      ...(note ? { note } : {}),
+      ...(parentV ? { parentV } : {}),
+      sha256: this.hashContent(content),
+    });
+    await this.writeIndex(versionDir, entries);
 
-      // Write the version file
-      const versionFile = join(versionDir, `v${nextV}.md`);
-      await writeFile(versionFile, content, 'utf-8');
-
-      // Update index
-      const entry: VersionEntry = {
-        v: nextV,
-        author,
-        ts: Date.now(),
-        ...(note && { note }),
-        ...(parentV && { parentV }),
-        sha256: sha,
-      };
-      index.entries.push(entry);
-      index.currentV = nextV;
-
-      await writeFile(indexPath, JSON.stringify(index, null, 2), 'utf-8');
-
-      log.debug(`Appended v${nextV} for ${stepFilePath} (author: ${author})`);
-      return nextV;
-    } catch (err) {
-      log.error(`Failed to append version for ${stepFilePath}:`, err);
-      throw err;
-    }
+    log.debug(`Appended v${v} for step ${stepId} (author: ${author})`);
+    return v;
   }
 
   /**
-   * Get the list of all versions for a step.
+   * List a step's version history. `canonicalFilePath`, when passed, is the
+   * flat `<stepId>-<label>.md` pointer file — used ONLY to lazily seed v1 the
+   * first time history is requested for a step that predates versioning.
    */
-  async getVersions(stepFilePath: string): Promise<VersionEntry[]> {
-    try {
-      const indexPath = join(this.getVersionDir(stepFilePath), 'index.json');
+  async getVersions(
+    projectDir: string,
+    stepId: string,
+    canonicalFilePath?: string,
+  ): Promise<VersionEntry[]> {
+    const versionDir = this.getVersionDir(projectDir, stepId);
+    let entries = await this.readIndex(versionDir);
 
-      if (!existsSync(indexPath)) {
-        // Lazy migration: check if the step file exists and seed v1
-        if (existsSync(stepFilePath)) {
-          const versionDir = this.getVersionDir(stepFilePath);
-          await this.seedV1FromExisting(stepFilePath, versionDir, indexPath);
-        } else {
-          return [];
-        }
-      }
-
-      const indexData = await readFile(indexPath, 'utf-8');
-      const index: VersionIndex = JSON.parse(indexData);
-      return index.entries;
-    } catch (err) {
-      log.error(`Failed to get versions for ${stepFilePath}:`, err);
-      return [];
+    if (entries.length === 0 && canonicalFilePath && existsSync(canonicalFilePath)) {
+      await this.seedV1FromExisting(projectDir, stepId, canonicalFilePath);
+      entries = await this.readIndex(versionDir);
     }
+
+    return entries;
   }
 
   /**
    * Restore an old version by creating a NEW version with that content.
-   * Never mutates history.
+   * Never mutates or rewrites the restored version.
    */
-  async restoreVersion(stepFilePath: string, versionNumber: number): Promise<number> {
+  async restoreVersion(projectDir: string, stepId: string, versionNumber: number): Promise<number> {
+    const content = await this.getVersionContent(projectDir, stepId, versionNumber);
+    if (content === null) {
+      throw new Error(`Version v${versionNumber} not found for step ${stepId}`);
+    }
+    return this.appendVersion(projectDir, stepId, content, 'agent-patch', `Restored from v${versionNumber}`);
+  }
+
+  /** Get the content of a specific version, or null if it doesn't exist. */
+  async getVersionContent(projectDir: string, stepId: string, versionNumber: number): Promise<string | null> {
+    const versionFile = join(this.getVersionDir(projectDir, stepId), `v${versionNumber}.md`);
+    if (!existsSync(versionFile)) return null;
+    return readFile(versionFile, 'utf-8');
+  }
+
+  /** Get the current (highest) version number for a step, or 0 if none exist. */
+  async getCurrentVersion(projectDir: string, stepId: string): Promise<number> {
+    const entries = await this.readIndex(this.getVersionDir(projectDir, stepId));
+    return entries.length ? entries[entries.length - 1].v : 0;
+  }
+
+  /** Seed v1 from an existing pre-versioning step file (lazy migration). */
+  private async seedV1FromExisting(projectDir: string, stepId: string, canonicalFilePath: string): Promise<void> {
+    const content = await readFile(canonicalFilePath, 'utf-8');
+    await this.appendVersion(projectDir, stepId, content, 'agent', 'Seeded from pre-existing step file');
+    log.debug(`Seeded v1 for step ${stepId} from ${canonicalFilePath}`);
+  }
+
+  private async readIndex(versionDir: string): Promise<VersionEntry[]> {
+    const indexPath = join(versionDir, 'index.json');
+    if (!existsSync(indexPath)) return [];
     try {
-      const versionDir = this.getVersionDir(stepFilePath);
-      const sourceFile = join(versionDir, `v${versionNumber}.md`);
-
-      if (!existsSync(sourceFile)) {
-        throw new Error(`Version ${versionNumber} not found`);
-      }
-
-      const content = await readFile(sourceFile, 'utf-8');
-      const newV = await this.appendVersion(
-        stepFilePath,
-        content,
-        'agent-patch',
-        `Restored from v${versionNumber}`
-      );
-
-      return newV;
+      return JSON.parse(await readFile(indexPath, 'utf-8'));
     } catch (err) {
-      log.error(`Failed to restore version for ${stepFilePath}:`, err);
-      throw err;
+      log.error(`Failed to parse ${indexPath}:`, err);
+      return [];
     }
   }
 
-  /**
-   * Get the content of a specific version.
-   */
-  async getVersionContent(stepFilePath: string, versionNumber: number): Promise<string | null> {
-    try {
-      const versionFile = join(this.getVersionDir(stepFilePath), `v${versionNumber}.md`);
-      if (!existsSync(versionFile)) return null;
-      return await readFile(versionFile, 'utf-8');
-    } catch (err) {
-      log.error(`Failed to read version ${versionNumber} for ${stepFilePath}:`, err);
-      return null;
-    }
+  private async writeIndex(versionDir: string, entries: VersionEntry[]): Promise<void> {
+    await writeFile(join(versionDir, 'index.json'), JSON.stringify(entries, null, 2), 'utf-8');
   }
 
-  /**
-   * Get the current version number for a step.
-   */
-  async getCurrentVersion(stepFilePath: string): Promise<number> {
-    try {
-      const indexPath = join(this.getVersionDir(stepFilePath), 'index.json');
-
-      if (!existsSync(indexPath)) {
-        if (existsSync(stepFilePath)) {
-          const versionDir = this.getVersionDir(stepFilePath);
-          await this.seedV1FromExisting(stepFilePath, versionDir, indexPath);
-        } else {
-          return 0;
-        }
-      }
-
-      const indexData = await readFile(indexPath, 'utf-8');
-      const index: VersionIndex = JSON.parse(indexData);
-      return index.currentV;
-    } catch (err) {
-      log.error(`Failed to get current version for ${stepFilePath}:`, err);
-      return 0;
-    }
-  }
-
-  /**
-   * Private: seed v1 from an existing step file (lazy migration).
-   * Called the first time history is requested for a pre-existing step.
-   */
-  private async seedV1FromExisting(
-    stepFilePath: string,
-    versionDir: string,
-    indexPath: string
-  ): Promise<void> {
-    try {
-      // Read the existing step file
-      const content = await readFile(stepFilePath, 'utf-8');
-      const sha = this.hashContent(content);
-
-      // Write it as v1
-      await mkdir(versionDir, { recursive: true });
-      await writeFile(join(versionDir, 'v1.md'), content, 'utf-8');
-
-      // Create the index
-      const index: VersionIndex = {
-        entries: [
-          {
-            v: 1,
-            author: 'agent',
-            ts: Date.now(),
-            note: 'Seeded from pre-existing step file',
-            sha256: sha,
-          },
-        ],
-        currentV: 1,
-      };
-
-      await writeFile(indexPath, JSON.stringify(index, null, 2), 'utf-8');
-      log.debug(`Seeded v1 from existing ${stepFilePath}`);
-    } catch (err) {
-      log.error(`Failed to seed v1 from ${stepFilePath}:`, err);
-      throw err;
-    }
-  }
-
-  /**
-   * Private: compute SHA256 hash of content for integrity checking.
-   */
   private hashContent(content: string): string {
     return createHash('sha256').update(content, 'utf-8').digest('hex');
   }
 
-  /**
-   * Private: compute the version directory path for a step file.
-   * step-file: workspace/projects/<slug>/<stepId>-<label>.md
-   * version-dir: workspace/projects/<slug>/.versions/<stepId>/
-   *
-   * stepId extraction: the format is always "${activeStep.id}-${label}". The stepId
-   * part is either:
-   *   - A full UUID like "550e8400-e29b-41d4-a716-446655440000" (4 dashes, 5 parts)
-   *   - A short ID like "abc123" (no dashes, 1 part)
-   *
-   * Heuristic: if the first dash-separated part is 8 hex characters, treat it as
-   * a UUID and extract the first 5 parts (the full UUID). Otherwise, take just
-   * the first part (the short ID).
-   */
-  private getVersionDir(stepFilePath: string): string {
-    const dir = dirname(stepFilePath);
-    const fileName = stepFilePath.replace(/\\/g, '/').split('/').pop() || 'unknown';
-    // Remove .md extension
-    const nameWithoutExt = fileName.replace(/\.md$/, '');
-    const parts = nameWithoutExt.split('-');
-
-    let stepId: string;
-    if (parts.length === 1) {
-      // No dashes — the whole thing is the ID
-      stepId = nameWithoutExt;
-    } else if (/^[0-9a-f]{8}$/.test(parts[0])) {
-      // First part looks like UUID segment (8 hex chars) — extract full UUID (5 parts)
-      stepId = parts.slice(0, Math.min(5, parts.length)).join('-');
-    } else {
-      // Short ID without UUID format — take just the first part
-      stepId = parts[0];
-    }
-
-    return join(dir, '.versions', stepId);
+  private getVersionDir(projectDir: string, stepId: string): string {
+    return join(projectDir, '.versions', stepId);
   }
 }
 

--- a/gateway/src/services/doc-versions.ts
+++ b/gateway/src/services/doc-versions.ts
@@ -1,0 +1,281 @@
+/**
+ * Document Versioning Service for AuthorAgent
+ *
+ * Immutable version history for step outputs. Storage structure:
+ * - workspace/projects/<slug>/.versions/<stepId>/
+ *   - v1.md, v2.md, ... (immutable version files)
+ *   - index.json (metadata: entries with v, author, ts, note, parentV, sha256)
+ * - workspace/projects/<slug>/<stepId>-<label>.md (canonical/current pointer)
+ *
+ * Migration is lazy: first time a pre-existing step's history is requested,
+ * seed v1 from the current .md file without downtime.
+ *
+ * Versioning is immutable. Restoring an old version creates a NEW version
+ * with that content — it never rewrites history.
+ */
+
+import { mkdir, writeFile, readFile, readdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { createHash } from 'crypto';
+import { logger } from './logger.js';
+
+const log = logger.child('[doc-versions]');
+
+interface VersionEntry {
+  v: number;
+  author: 'agent' | 'user' | 'agent-patch';
+  ts: number;
+  note?: string;
+  parentV?: number;
+  sha256: string;
+}
+
+interface VersionIndex {
+  entries: VersionEntry[];
+  currentV: number;
+}
+
+export class DocVersionService {
+  /**
+   * Append a new version for a step. Returns the version number.
+   * Author: 'agent' for AI-generated, 'user' for manual edits, 'agent-patch' for auto-corrections.
+   */
+  async appendVersion(
+    stepFilePath: string,
+    content: string,
+    author: 'agent' | 'user' | 'agent-patch' = 'agent',
+    note?: string
+  ): Promise<number> {
+    try {
+      const versionDir = this.getVersionDir(stepFilePath);
+      const indexPath = join(versionDir, 'index.json');
+
+      // Ensure version directory exists
+      await mkdir(versionDir, { recursive: true });
+
+      // Read or create the index
+      let index: VersionIndex;
+      if (existsSync(indexPath)) {
+        const indexData = await readFile(indexPath, 'utf-8');
+        index = JSON.parse(indexData);
+      } else {
+        // Check if this is a pre-existing step (needs lazy migration)
+        if (existsSync(stepFilePath)) {
+          await this.seedV1FromExisting(stepFilePath, versionDir, indexPath);
+          const indexData = await readFile(indexPath, 'utf-8');
+          index = JSON.parse(indexData);
+        } else {
+          index = { entries: [], currentV: 0 };
+        }
+      }
+
+      // Compute next version number and SHA256
+      const nextV = index.currentV + 1;
+      const sha = this.hashContent(content);
+      const parentV = index.currentV > 0 ? index.currentV : undefined;
+
+      // Write the version file
+      const versionFile = join(versionDir, `v${nextV}.md`);
+      await writeFile(versionFile, content, 'utf-8');
+
+      // Update index
+      const entry: VersionEntry = {
+        v: nextV,
+        author,
+        ts: Date.now(),
+        ...(note && { note }),
+        ...(parentV && { parentV }),
+        sha256: sha,
+      };
+      index.entries.push(entry);
+      index.currentV = nextV;
+
+      await writeFile(indexPath, JSON.stringify(index, null, 2), 'utf-8');
+
+      log.debug(`Appended v${nextV} for ${stepFilePath} (author: ${author})`);
+      return nextV;
+    } catch (err) {
+      log.error(`Failed to append version for ${stepFilePath}:`, err);
+      throw err;
+    }
+  }
+
+  /**
+   * Get the list of all versions for a step.
+   */
+  async getVersions(stepFilePath: string): Promise<VersionEntry[]> {
+    try {
+      const indexPath = join(this.getVersionDir(stepFilePath), 'index.json');
+
+      if (!existsSync(indexPath)) {
+        // Lazy migration: check if the step file exists and seed v1
+        if (existsSync(stepFilePath)) {
+          const versionDir = this.getVersionDir(stepFilePath);
+          await this.seedV1FromExisting(stepFilePath, versionDir, indexPath);
+        } else {
+          return [];
+        }
+      }
+
+      const indexData = await readFile(indexPath, 'utf-8');
+      const index: VersionIndex = JSON.parse(indexData);
+      return index.entries;
+    } catch (err) {
+      log.error(`Failed to get versions for ${stepFilePath}:`, err);
+      return [];
+    }
+  }
+
+  /**
+   * Restore an old version by creating a NEW version with that content.
+   * Never mutates history.
+   */
+  async restoreVersion(stepFilePath: string, versionNumber: number): Promise<number> {
+    try {
+      const versionDir = this.getVersionDir(stepFilePath);
+      const sourceFile = join(versionDir, `v${versionNumber}.md`);
+
+      if (!existsSync(sourceFile)) {
+        throw new Error(`Version ${versionNumber} not found`);
+      }
+
+      const content = await readFile(sourceFile, 'utf-8');
+      const newV = await this.appendVersion(
+        stepFilePath,
+        content,
+        'agent-patch',
+        `Restored from v${versionNumber}`
+      );
+
+      return newV;
+    } catch (err) {
+      log.error(`Failed to restore version for ${stepFilePath}:`, err);
+      throw err;
+    }
+  }
+
+  /**
+   * Get the content of a specific version.
+   */
+  async getVersionContent(stepFilePath: string, versionNumber: number): Promise<string | null> {
+    try {
+      const versionFile = join(this.getVersionDir(stepFilePath), `v${versionNumber}.md`);
+      if (!existsSync(versionFile)) return null;
+      return await readFile(versionFile, 'utf-8');
+    } catch (err) {
+      log.error(`Failed to read version ${versionNumber} for ${stepFilePath}:`, err);
+      return null;
+    }
+  }
+
+  /**
+   * Get the current version number for a step.
+   */
+  async getCurrentVersion(stepFilePath: string): Promise<number> {
+    try {
+      const indexPath = join(this.getVersionDir(stepFilePath), 'index.json');
+
+      if (!existsSync(indexPath)) {
+        if (existsSync(stepFilePath)) {
+          const versionDir = this.getVersionDir(stepFilePath);
+          await this.seedV1FromExisting(stepFilePath, versionDir, indexPath);
+        } else {
+          return 0;
+        }
+      }
+
+      const indexData = await readFile(indexPath, 'utf-8');
+      const index: VersionIndex = JSON.parse(indexData);
+      return index.currentV;
+    } catch (err) {
+      log.error(`Failed to get current version for ${stepFilePath}:`, err);
+      return 0;
+    }
+  }
+
+  /**
+   * Private: seed v1 from an existing step file (lazy migration).
+   * Called the first time history is requested for a pre-existing step.
+   */
+  private async seedV1FromExisting(
+    stepFilePath: string,
+    versionDir: string,
+    indexPath: string
+  ): Promise<void> {
+    try {
+      // Read the existing step file
+      const content = await readFile(stepFilePath, 'utf-8');
+      const sha = this.hashContent(content);
+
+      // Write it as v1
+      await mkdir(versionDir, { recursive: true });
+      await writeFile(join(versionDir, 'v1.md'), content, 'utf-8');
+
+      // Create the index
+      const index: VersionIndex = {
+        entries: [
+          {
+            v: 1,
+            author: 'agent',
+            ts: Date.now(),
+            note: 'Seeded from pre-existing step file',
+            sha256: sha,
+          },
+        ],
+        currentV: 1,
+      };
+
+      await writeFile(indexPath, JSON.stringify(index, null, 2), 'utf-8');
+      log.debug(`Seeded v1 from existing ${stepFilePath}`);
+    } catch (err) {
+      log.error(`Failed to seed v1 from ${stepFilePath}:`, err);
+      throw err;
+    }
+  }
+
+  /**
+   * Private: compute SHA256 hash of content for integrity checking.
+   */
+  private hashContent(content: string): string {
+    return createHash('sha256').update(content, 'utf-8').digest('hex');
+  }
+
+  /**
+   * Private: compute the version directory path for a step file.
+   * step-file: workspace/projects/<slug>/<stepId>-<label>.md
+   * version-dir: workspace/projects/<slug>/.versions/<stepId>/
+   *
+   * stepId extraction: the format is always "${activeStep.id}-${label}". The stepId
+   * part is either:
+   *   - A full UUID like "550e8400-e29b-41d4-a716-446655440000" (4 dashes, 5 parts)
+   *   - A short ID like "abc123" (no dashes, 1 part)
+   *
+   * Heuristic: if the first dash-separated part is 8 hex characters, treat it as
+   * a UUID and extract the first 5 parts (the full UUID). Otherwise, take just
+   * the first part (the short ID).
+   */
+  private getVersionDir(stepFilePath: string): string {
+    const dir = dirname(stepFilePath);
+    const fileName = stepFilePath.replace(/\\/g, '/').split('/').pop() || 'unknown';
+    // Remove .md extension
+    const nameWithoutExt = fileName.replace(/\.md$/, '');
+    const parts = nameWithoutExt.split('-');
+
+    let stepId: string;
+    if (parts.length === 1) {
+      // No dashes — the whole thing is the ID
+      stepId = nameWithoutExt;
+    } else if (/^[0-9a-f]{8}$/.test(parts[0])) {
+      // First part looks like UUID segment (8 hex chars) — extract full UUID (5 parts)
+      stepId = parts.slice(0, Math.min(5, parts.length)).join('-');
+    } else {
+      // Short ID without UUID format — take just the first part
+      stepId = parts[0];
+    }
+
+    return join(dir, '.versions', stepId);
+  }
+}
+
+export const docVersionService = new DocVersionService();

--- a/gateway/src/services/gate-state-machine.test.ts
+++ b/gateway/src/services/gate-state-machine.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveStepGate,
+  applyStepCompletion,
+  GATED_PHASES_DEFAULT,
+  type Project,
+  type ProjectStep,
+} from './project-templates.js';
+
+function makeProject(context: Project['context'] = {}): Project {
+  return {
+    id: 'p1',
+    type: 'novel-pipeline',
+    title: 'Test',
+    description: '',
+    status: 'active',
+    progress: 0,
+    steps: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    context,
+  };
+}
+
+function makeStep(overrides: Partial<ProjectStep> = {}): ProjectStep {
+  return {
+    id: 's1',
+    label: 'Step',
+    taskType: 'general',
+    prompt: 'do it',
+    status: 'active',
+    ...overrides,
+  };
+}
+
+describe('resolveStepGate', () => {
+  it('applies the locked template default: premise/bible/outline gate', () => {
+    const project = makeProject();
+    for (const phase of ['premise', 'bible', 'outline']) {
+      expect(resolveStepGate(makeStep({ phase }), project)).toBe(true);
+    }
+  });
+
+  it('applies the locked template default: writing/revision/polish/assembly auto', () => {
+    const project = makeProject();
+    for (const phase of ['writing', 'revision', 'polish', 'assembly']) {
+      expect(resolveStepGate(makeStep({ phase }), project)).toBe(false);
+    }
+  });
+
+  it('never gates a phase-less step by default', () => {
+    const project = makeProject();
+    expect(resolveStepGate(makeStep({ phase: undefined }), project)).toBe(false);
+  });
+
+  it('context.reviewGates overrides the template default for its phase', () => {
+    const project = makeProject({ reviewGates: { writing: true, outline: false } });
+    expect(resolveStepGate(makeStep({ phase: 'writing' }), project)).toBe(true);
+    expect(resolveStepGate(makeStep({ phase: 'outline' }), project)).toBe(false);
+    // Phases not mentioned in reviewGates still fall through to the template default.
+    expect(resolveStepGate(makeStep({ phase: 'bible' }), project)).toBe(true);
+  });
+
+  it('step.gateEnabled wins over both reviewGates and the template default', () => {
+    const project = makeProject({ reviewGates: { outline: true } });
+    expect(resolveStepGate(makeStep({ phase: 'outline', gateEnabled: false }), project)).toBe(false);
+    expect(resolveStepGate(makeStep({ phase: 'writing', gateEnabled: true }), project)).toBe(true);
+  });
+
+  it('GATED_PHASES_DEFAULT is exactly premise/bible/outline', () => {
+    expect(Array.from(GATED_PHASES_DEFAULT).sort()).toEqual(['bible', 'outline', 'premise']);
+  });
+});
+
+describe('applyStepCompletion', () => {
+  it('a gated step reaching completion enters awaiting_review with an open gate, not completed', () => {
+    const project = makeProject();
+    const step = makeStep({ phase: 'outline' });
+
+    applyStepCompletion(step, project, 'the outline text', '2026-01-02T00:00:00.000Z');
+
+    expect(step.status).toBe('awaiting_review');
+    expect(step.result).toBe('the outline text');
+    expect(step.gate).toEqual({ state: 'open', openedAt: '2026-01-02T00:00:00.000Z' });
+  });
+
+  it('an ungated step completes exactly as it does today — byte-for-byte', () => {
+    const project = makeProject();
+    const step = makeStep({ phase: 'writing' });
+
+    applyStepCompletion(step, project, 'chapter prose', '2026-01-02T00:00:00.000Z');
+
+    expect(step).toEqual(makeStep({ phase: 'writing', status: 'completed', result: 'chapter prose' }));
+    expect(step.gate).toBeUndefined();
+  });
+
+  it('respects a per-step gateEnabled override even for an auto-default phase', () => {
+    const project = makeProject();
+    const step = makeStep({ phase: 'writing', gateEnabled: true });
+
+    applyStepCompletion(step, project, 'chapter prose');
+
+    expect(step.status).toBe('awaiting_review');
+    expect(step.gate?.state).toBe('open');
+  });
+
+  it('respects context.reviewGates turning off a normally-gated phase', () => {
+    const project = makeProject({ reviewGates: { premise: false } });
+    const step = makeStep({ phase: 'premise' });
+
+    applyStepCompletion(step, project, 'premise text');
+
+    expect(step.status).toBe('completed');
+    expect(step.gate).toBeUndefined();
+  });
+});

--- a/gateway/src/services/heartbeat.test.ts
+++ b/gateway/src/services/heartbeat.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Heartbeat autonomous-mode gate-blocking (M1.3 — ALP-1557).
+ *
+ * A gated step (StepExecutor.runStep opening a review gate instead of
+ * completing — see step-executor-conductor.test.ts for the executor side)
+ * must never be treated as a failure by the autonomous wake cycle: no
+ * ❌ broadcast, no 'difficulty' journal entry, no contribution to
+ * stepsThisWake / totalAutonomousSteps (the "failure or retry budget").
+ * autonomousWake() is private; called directly via a cast, same as any
+ * other white-box unit test of a private method.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { HeartbeatService, type AutonomousRunFunc, type AutonomousProjectListFunc } from './heartbeat.js';
+import { MemoryService } from './memory.js';
+
+let memoryDir: string;
+
+beforeEach(async () => {
+  memoryDir = await mkdtemp(join(tmpdir(), 'heartbeat-test-'));
+});
+afterEach(async () => {
+  await rm(memoryDir, { recursive: true, force: true });
+});
+
+/** quietHoursStart === quietHoursEnd (both 0) never trips the quiet-hours guard, at any hour. */
+function makeHeartbeat(): HeartbeatService {
+  const memory = new MemoryService(memoryDir, {});
+  return new HeartbeatService({
+    autonomousEnabled: true,
+    quietHoursStart: 0,
+    quietHoursEnd: 0,
+    maxAutonomousStepsPerWake: 5,
+  }, memory);
+}
+
+const oneActiveProject: AutonomousProjectListFunc = () => [{
+  id: 'p1', title: 'Test Book', status: 'active', progress: '50%', progressNum: 50,
+  stepsRemaining: 1, type: 'novel-pipeline',
+}];
+
+describe('heartbeat autonomous mode never touches a gated step (M1.3 — ALP-1557)', () => {
+  it('a gated result is skipped silently — not counted toward failure or retry budgets', async () => {
+    const hb = makeHeartbeat();
+    const broadcasts: string[] = [];
+    let calls = 0;
+    const runStep: AutonomousRunFunc = async () => {
+      calls++;
+      return { gated: true, step: 'Outline' };
+    };
+
+    hb.setAutonomous(runStep, oneActiveProject, (msg) => broadcasts.push(msg));
+    await (hb as any).autonomousWake();
+
+    // Never retried within the same wake cycle despite maxAutonomousStepsPerWake=5.
+    expect(calls).toBe(1);
+
+    const status = hb.getAutonomousStatus();
+    expect(status.totalStepsExecuted).toBe(0);
+    expect(status.totalWordsGenerated).toBe(0);
+
+    // No alarming failure broadcast — a gate is not a breakage.
+    expect(broadcasts.some(m => m.includes('❌'))).toBe(false);
+    expect(broadcasts.some(m => m.includes('🔒'))).toBe(true);
+
+    // Journal records it as 'idle' (a pause), never 'difficulty' (a failure).
+    const journal = hb.getJournal();
+    expect(journal.some(e => e.type === 'difficulty')).toBe(false);
+    expect(journal.some(e => e.type === 'idle' && e.message.includes('review gate'))).toBe(true);
+  });
+
+  it('does not mistake a gate for project completion (no false "complete!" message)', async () => {
+    const hb = makeHeartbeat();
+    const broadcasts: string[] = [];
+    const runStep: AutonomousRunFunc = async () => ({ gated: true, step: 'Bible' });
+
+    hb.setAutonomous(runStep, oneActiveProject, (msg) => broadcasts.push(msg));
+    await (hb as any).autonomousWake();
+
+    expect(broadcasts.some(m => m.includes('complete'))).toBe(false);
+  });
+
+  it('a mid-run failure is still reported and counted as a failure (gate handling did not swallow real errors)', async () => {
+    const hb = makeHeartbeat();
+    const broadcasts: string[] = [];
+    const runStep: AutonomousRunFunc = async () => ({ error: 'boom' });
+
+    hb.setAutonomous(runStep, oneActiveProject, (msg) => broadcasts.push(msg));
+    await (hb as any).autonomousWake();
+
+    expect(broadcasts.some(m => m.includes('❌'))).toBe(true);
+    const journal = hb.getJournal();
+    expect(journal.some(e => e.type === 'difficulty')).toBe(true);
+  });
+
+  it('a project with no actionable steps left (fully blocked behind a gate) is never selected at all', async () => {
+    const hb = makeHeartbeat();
+    let calls = 0;
+    const runStep: AutonomousRunFunc = async () => { calls++; return { gated: true, step: 'x' }; };
+    // stepsRemaining only counts pending/active steps — an awaiting_review
+    // step (the gate) falls out of that count for free, so a project whose
+    // only remaining step is gated reports 0 remaining and is filtered out
+    // before autonomousRunStep is ever called.
+    const listProjects: AutonomousProjectListFunc = () => [{
+      id: 'p1', title: 'Fully Gated', status: 'active', progress: '90%', progressNum: 90,
+      stepsRemaining: 0, type: 'novel-pipeline',
+    }];
+
+    hb.setAutonomous(runStep, listProjects, () => {});
+    await (hb as any).autonomousWake();
+
+    expect(calls).toBe(0);
+  });
+});

--- a/gateway/src/services/heartbeat.ts
+++ b/gateway/src/services/heartbeat.ts
@@ -34,9 +34,16 @@ interface HeartbeatConfig {
  * Callback type for autonomous project execution.
  * Injected by the gateway so heartbeat can trigger project steps
  * without importing the project engine or AI router directly.
+ *
+ * The `gated` outcome (M1.3 — ALP-1557) is neither success nor failure: the
+ * step produced content but opened a review gate instead of completing.
+ * Distinct from `error` so autonomousWake() never counts it as a failure or
+ * retries against it — it's a "stop and wait for a human" signal, not a bug.
  */
 export type AutonomousRunFunc = (projectId: string) => Promise<
-  { completed: string; response: string; wordCount: number; nextStep?: string } | { error: string }
+  | { completed: string; response: string; wordCount: number; nextStep?: string }
+  | { error: string }
+  | { gated: true; step: string }
 >;
 
 export type AutonomousProjectListFunc = () => Array<{
@@ -515,6 +522,21 @@ export class HeartbeatService {
         }
 
         const result = await this.autonomousRunStep(targetProject.id);
+
+        // A gate (M1.3 — ALP-1557) is not a failure — the step produced
+        // content and is waiting on human review. Stop working this project
+        // for the rest of this wake cycle WITHOUT touching stepsThisWake /
+        // totalAutonomousSteps and WITHOUT the ❌ failure broadcast: a gated
+        // step must never count toward failure or retry budgets.
+        if ('gated' in result) {
+          this.logAutonomous(
+            `"${result.step}" opened a review gate — pausing autonomous work on "${targetProject.title}" until it's reviewed`,
+            'idle',
+            { projectId: targetProject.id, step: result.step }
+          );
+          this.broadcast(`🔒 "${result.step}" is ready for your review — autonomous mode is pausing on "${targetProject.title}" until you decide.`);
+          break;
+        }
 
         if ('error' in result) {
           this.logAutonomous(`Step failed: ${result.error}`, 'difficulty', { projectId: targetProject.id });

--- a/gateway/src/services/install-root.ts
+++ b/gateway/src/services/install-root.ts
@@ -1,0 +1,37 @@
+/**
+ * Install root resolution + .env loading, shared by gateway/src/index.ts and
+ * the `book` CLI (gateway/src/cli/book.ts). Extracted from index.ts so both
+ * entry points resolve ROOT_DIR and load .env identically — a second copy of
+ * this logic that drifted would silently reintroduce the exact bug this file
+ * originally fixed (.env resolving relative to cwd instead of the install
+ * directory; see git history on index.ts around AUTHORCLAW_WORKSPACE_DIR).
+ */
+
+import { config as loadDotenv } from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+/**
+ * Resolve ROOT_DIR from a caller's `import.meta.url`. `upsFromSrc` is how many
+ * directories separate the caller from ROOT_DIR when running from source
+ * (e.g. 2 for `gateway/src/index.ts`, 3 for `gateway/src/cli/book.ts`); a
+ * `dist/` build output adds exactly one more level of nesting on top of that.
+ */
+export function resolveInstallRootDir(callerImportMetaUrl: string, upsFromSrc: number): string {
+  const callerDir = dirname(fileURLToPath(callerImportMetaUrl));
+  const ups = callerDir.includes('dist') ? upsFromSrc + 1 : upsFromSrc;
+  return join(callerDir, ...Array(ups).fill('..'));
+}
+
+/**
+ * Load `<rootDir>/.env`. A missing file is a normal, silent no-op for
+ * installs that don't use one; any other load error is worth a visible
+ * warning since a swallowed load failure means every env override silently
+ * reverts to its default (this bit AUTHORCLAW_WORKSPACE_DIR once already).
+ */
+export function loadInstallDotenv(rootDir: string): void {
+  const result = loadDotenv({ path: join(rootDir, '.env') });
+  if (result.error && (result.error as NodeJS.ErrnoException).code !== 'ENOENT') {
+    console.warn(`[startup] .env failed to load from ${join(rootDir, '.env')}: ${result.error.message}`);
+  }
+}

--- a/gateway/src/services/m1-regression.test.ts
+++ b/gateway/src/services/m1-regression.test.ts
@@ -1,0 +1,161 @@
+/**
+ * M1 exit-criterion regression (ALP-1560, plan.md "M1 — Foundations").
+ *
+ * "A pre-existing project created before this work still runs to completion
+ * unchanged, with gates off." Real in-flight novel-pipeline projects predating
+ * this fork have already cleared their premise/bible/outline steps — those
+ * phases run first, and gating landed after real users already had books in
+ * progress. Only writing/revision/assembly remain for such a project, and
+ * those phases are auto (ungated) by GATED_PHASES_DEFAULT.
+ *
+ * This builds a project from the real production template (buildNovelPipelineSteps
+ * — real phases, real dependsOn graph), fast-forwards it to that realistic
+ * mid-flight state, and drives it through the real conductor with the real
+ * gate-resolution code (resolveStepGate / applyStepCompletion are NOT stubbed)
+ * to prove nothing gates and the run completes exactly as it would have
+ * before M1.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  StepExecutor,
+  type EnginePort,
+  type StepExecutorDeps,
+  type MessageHandler,
+} from './step-executor.js';
+import { buildNovelPipelineSteps, type Project } from './project-templates.js';
+
+const LONG = 'word '.repeat(60); // >50 chars — clears the "unusably short response" retry path
+
+function makeEngine(project: Project): EnginePort {
+  return {
+    getProject: (id) => (id === project.id ? project : undefined),
+    completeStep: (_pid, sid, result) => {
+      const s = project.steps.find(x => x.id === sid);
+      if (s) { s.status = 'completed'; s.result = result; }
+      const next = project.steps.find(x => x.status === 'pending');
+      if (next) { next.status = 'active'; return next; }
+      const remaining = project.steps.filter(x => x.status === 'pending' || x.status === 'active');
+      if (remaining.length === 0) project.status = 'completed';
+      return null;
+    },
+    completeStepBare: (_pid, sid, result) => {
+      const s = project.steps.find(x => x.id === sid);
+      if (s) { s.status = 'completed'; s.result = result; }
+      const remaining = project.steps.filter(x => x.status === 'pending' || x.status === 'active');
+      if (remaining.length === 0 && project.status !== 'paused') project.status = 'completed';
+    },
+    openStepGate: (_pid, sid) => {
+      // A pre-existing project must NEVER open a gate — fail loudly if it does.
+      throw new Error(`unexpected gate opened on step ${sid} — a pre-existing project must run unchanged`);
+    },
+    activateStep: (_pid, sid) => {
+      const s = project.steps.find(x => x.id === sid);
+      if (s) s.status = 'active';
+      return s || null;
+    },
+    failStep: (_pid, sid, error) => {
+      const s = project.steps.find(x => x.id === sid);
+      if (s) { s.status = 'failed'; s.error = error; }
+    },
+    buildProjectContext: async () => '',
+  };
+}
+
+const handler: MessageHandler = async (_content, _channel, respond) => { respond(LONG); };
+
+const deps: StepExecutorDeps = {
+  getMessageHandler: () => handler,
+  getStepServices: () => ({}),
+  getContextEngine: () => undefined,
+};
+
+describe('M1 regression — a pre-existing project runs to completion unchanged', () => {
+  it('a novel-pipeline project already past premise/bible/outline gates on nothing and completes', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'm1-regression-'));
+    const workspaceDir = join(rootDir, 'workspace');
+
+    const { steps, chapters } = buildNovelPipelineSteps('legacy1', 'Legacy Book', 'A pre-fork project', {
+      targetChapters: 2, targetWordsPerChapter: 100,
+    });
+
+    // Fast-forward to the realistic "already in flight" state: every
+    // premise/bible/outline step already completed, as any real project
+    // running before this fork would be (those phases run first).
+    for (const s of steps) {
+      if (s.phase === 'premise' || s.phase === 'bible' || s.phase === 'outline') {
+        s.status = 'completed';
+        s.result = `[pre-fork output] ${s.label}`;
+      }
+    }
+
+    const project: Project = {
+      id: 'legacy1',
+      type: 'novel-pipeline',
+      title: 'Legacy Book',
+      description: 'A pre-fork project',
+      status: 'active',
+      progress: 0,
+      steps,
+      createdAt: '2026-01-01T00:00:00.000Z', // predates this work
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      context: {}, // no reviewGates override — nothing fork-specific was ever set on this project
+    };
+
+    const exec = new StepExecutor(makeEngine(project), deps);
+    const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
+
+    try {
+      // Nothing gated — every dispatched step is a plain success.
+      expect(results.every(r => r.success && !r.gated)).toBe(true);
+      // Exactly the remaining steps ran: N chapters + 3 revision steps + 1 assembly.
+      expect(results.length).toBe(chapters + 3 + 1);
+      expect(project.steps.every(s => s.status === 'completed')).toBe(true);
+      expect(project.steps.every(s => s.gate === undefined)).toBe(true);
+      expect(project.status).toBe('completed');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a fresh legacy project (no dependsOn at all) still runs strictly sequentially with no gates', async () => {
+    // The oldest possible persisted shape — predates even the conductor engine.
+    // No `phase` is set on any step, so resolveStepGate() falls through to
+    // "never gates a phase-less step by default" for every single step.
+    const rootDir = mkdtempSync(join(tmpdir(), 'm1-regression-legacy-'));
+    const workspaceDir = join(rootDir, 'workspace');
+
+    const project: Project = {
+      id: 'ancient1',
+      type: 'book-production',
+      title: 'Ancient Book',
+      description: 'x',
+      status: 'active',
+      progress: 0,
+      steps: [
+        { id: 'L1', label: 'Step 1', taskType: 'general', prompt: 'do 1', status: 'active' },
+        { id: 'L2', label: 'Step 2', taskType: 'general', prompt: 'do 2', status: 'pending' },
+        { id: 'L3', label: 'Step 3', taskType: 'general', prompt: 'do 3', status: 'pending' },
+      ],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+      context: {},
+    };
+
+    const exec = new StepExecutor(makeEngine(project), deps);
+    const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
+
+    try {
+      expect(results.map(r => r.step)).toEqual(['Step 1', 'Step 2', 'Step 3']);
+      expect(results.every(r => r.success && !r.gated)).toBe(true);
+      expect(project.steps.every(s => s.status === 'completed' && s.gate === undefined)).toBe(true);
+      expect(project.status).toBe('completed');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/gateway/src/services/memory.test.ts
+++ b/gateway/src/services/memory.test.ts
@@ -50,7 +50,7 @@ describe('MemoryService.getRelevant — relevant-memory budget', () => {
     await memory.setActiveProject('proj-1');
     const result = await memory.getRelevant('keyword');
     expect(result.length).toBeLessThanOrEqual(8_000 + 300); // + header overhead across entries
-  });
+  }, 30000);
 
   it('keeps the highest-relevance-scored entries and drops the low-relevance tail when over budget', async () => {
     await memory.setActiveProject('proj-1');

--- a/gateway/src/services/memory.test.ts
+++ b/gateway/src/services/memory.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';

--- a/gateway/src/services/memory.test.ts
+++ b/gateway/src/services/memory.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { MemoryService } from './memory.js';
+
+// getRelevant() had zero test coverage despite being a section of the
+// system prompt that was, until this fix, entirely unbounded (up to
+// 10 files x 5,000 chars = 50,000 chars) and excluded from
+// message-pipeline's total-budget trim list — see the same-commit fix in
+// message-pipeline.ts (added 'memories' to applyTotalBudgetGuard's trim
+// order) and loader.ts (raised skill budget now that this is bounded).
+
+describe('MemoryService.getRelevant — relevant-memory budget', () => {
+  let memoryDir: string;
+  let memory: MemoryService;
+
+  beforeEach(async () => {
+    memoryDir = await mkdtemp(join(tmpdir(), 'authoragent-memory-test-'));
+    memory = new MemoryService(memoryDir, {});
+    await memory.initialize();
+  });
+
+  afterEach(async () => {
+    await rm(memoryDir, { recursive: true, force: true });
+  });
+
+  async function writeBibleFile(projectId: string, name: string, content: string) {
+    const dir = join(memoryDir, 'book-bible', projectId);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, name), content, 'utf-8');
+  }
+
+  it('returns empty string when no project is active', async () => {
+    expect(await memory.getRelevant('anything')).toBe('');
+  });
+
+  it('caps a single file excerpt at 5,000 chars, as before', async () => {
+    await memory.setActiveProject('proj-1');
+    await writeBibleFile('proj-1', 'character-alice.md', 'alice content '.repeat(1000)); // ~14,000 chars
+    const result = await memory.getRelevant('alice');
+    expect(result.length).toBeLessThanOrEqual(5_000 + 50); // + header overhead
+  });
+
+  it('caps the TOTAL accumulated block at 8,000 chars, even with many large matching files', async () => {
+    // Previously unbounded: 10 files x 5,000 chars = up to 50,000 chars total.
+    for (let i = 0; i < 10; i++) {
+      await writeBibleFile('proj-1', `entry-${i}.md`, `keyword content ${i} `.repeat(500)); // ~11,000 chars each
+    }
+    await memory.setActiveProject('proj-1');
+    const result = await memory.getRelevant('keyword');
+    expect(result.length).toBeLessThanOrEqual(8_000 + 300); // + header overhead across entries
+  });
+
+  it('keeps the highest-relevance-scored entries and drops the low-relevance tail when over budget', async () => {
+    await memory.setActiveProject('proj-1');
+    // Two high-relevance files (filename AND content match), each large
+    // enough to hit the 5,000-char per-file cap — together they exhaust the
+    // whole 8,000 budget on their own before the loop (in score order) ever
+    // reaches the zero-relevance file below.
+    await writeBibleFile('proj-1', 'dragon-lore.md', 'dragon dragon dragon '.repeat(600)); // ~13,200 chars, capped at 5,000
+    await writeBibleFile('proj-1', 'dragon-history.md', 'dragon backstory '.repeat(600)); // ~10,200 chars, capped at 5,000
+    // Zero-relevance: no keyword match at all — should be dropped once the
+    // two files above have already spent the full budget.
+    await writeBibleFile('proj-1', 'unrelated-notes.md', 'z'.repeat(1000));
+    const result = await memory.getRelevant('dragon');
+    expect(result).toContain('dragon-lore.md');
+    expect(result).toContain('dragon-history.md');
+    expect(result).not.toContain('unrelated-notes.md');
+  });
+
+  it('does not truncate when the total is already under budget', async () => {
+    await memory.setActiveProject('proj-1');
+    await writeBibleFile('proj-1', 'short.md', 'a short bible entry about the plot');
+    const result = await memory.getRelevant('plot');
+    expect(result).toContain('a short bible entry about the plot');
+    expect(result).not.toContain('[truncated]'); // getRelevant doesn't mark truncation explicitly, but the full string should survive
+  });
+});

--- a/gateway/src/services/memory.ts
+++ b/gateway/src/services/memory.ts
@@ -113,8 +113,24 @@ export class MemoryService {
         // Sort by relevance score descending, then alphabetically for ties
         scored.sort((a, b) => b.score - a.score || a.file.localeCompare(b.file));
 
+        // Budget the accumulated block, not just each entry. This was
+        // previously unbounded — up to 10 files x 5,000 chars = 50,000
+        // chars — and unlike every other system-prompt section, it wasn't
+        // in the trim list message-pipeline.ts applies when the total
+        // prompt runs over budget, so it could sit at the top of the
+        // context indefinitely. Since entries are already sorted by
+        // relevance, capping the running total here keeps the
+        // highest-signal material and drops the low-relevance tail,
+        // instead of leaving everything downstream to be truncated by an
+        // equal, arbitrary amount (or not at all).
+        const RELEVANT_MEMORY_BUDGET_CHARS = 8000;
+        let used = 0;
         for (const { file, content } of scored.slice(0, 10)) {
-          parts.push(`[${file}]: ${content.substring(0, 5000)}`);
+          if (used >= RELEVANT_MEMORY_BUDGET_CHARS) break;
+          const remaining = RELEVANT_MEMORY_BUDGET_CHARS - used;
+          const excerpt = content.substring(0, Math.min(5000, remaining));
+          parts.push(`[${file}]: ${excerpt}`);
+          used += excerpt.length;
         }
       }
     }

--- a/gateway/src/services/memory.ts
+++ b/gateway/src/services/memory.ts
@@ -220,6 +220,15 @@ export class MemoryService {
     await writeFile(join(dir, safeFile), content);
   }
 
+  /** Read back an entry saved via saveBookBibleEntry. Returns null if it doesn't exist yet. */
+  async getBookBibleEntry(projectId: string, filename: string): Promise<string | null> {
+    const safeProject = sanitizeSegment(projectId, 'project');
+    const safeFile = sanitizeSegment(filename, 'entry.md');
+    const filePath = join(this.memoryDir, 'book-bible', safeProject, safeFile);
+    if (!existsSync(filePath)) return null;
+    return readFile(filePath, 'utf-8');
+  }
+
   /**
    * Reset all memory — conversations, summaries, active project.
    * Preserves book-bible entries (project data) unless fullReset is true.

--- a/gateway/src/services/message-pipeline.ts
+++ b/gateway/src/services/message-pipeline.ts
@@ -208,11 +208,8 @@ export class MessagePipeline {
       heartbeatContext,
       channel,
       userMessage: content,
+      extraContext,
     });
-
-    if (extraContext) {
-      systemPrompt += '\n' + extraContext;
-    }
 
     // Append the injection caution (if a warn-level detection occurred above).
     if (injectionCaution) {
@@ -484,6 +481,10 @@ export class MessagePipeline {
     channel?: string;
     /** The user's raw message — keys CORE promotion + ARCHIVAL search. */
     userMessage?: string;
+    /** Project-step-specific context (bible slices, outline, prior steps).
+     *  See the total-budget-guard comment below for why this is a parameter
+     *  here rather than appended by the caller after this function returns. */
+    extraContext?: string;
   }): Promise<string> {
     let prompt = '';
 
@@ -553,9 +554,14 @@ export class MessagePipeline {
     }
     prompt += coreBlock;
 
+    // Captured into a named block (not appended inline) so it can be added
+    // to the total-budget guard's trim list below — this section was
+    // previously excluded from that list entirely, so on a large prompt the
+    // guard could never actually reach the cap when memory dominated it.
+    let relevantMemoryBlock = '';
     if (context.memories) {
-      prompt += '# Relevant Memory\n\n';
-      prompt += context.memories + '\n\n';
+      relevantMemoryBlock = '# Relevant Memory\n\n' + context.memories + '\n\n';
+      prompt += relevantMemoryBlock;
     }
 
     // ── Archival recall (ARCHIVAL) — Chunk B2 ──
@@ -702,15 +708,39 @@ export class MessagePipeline {
     prompt += '- Do NOT access any URL not on this list. If a user asks about a domain not listed, tell them it is approved but you need to use the research gate to fetch it.\n';
     prompt += '- Never share API keys, tokens, or vault contents\n';
 
+    // extraContext (project-step context: bible slices, outline, prior-step
+    // results — up to ~25K chars, or ~55K with an uploaded manuscript) used
+    // to be appended by the CALLER after this function returned, i.e. AFTER
+    // the budget guard below had already run — so it bypassed the 24K cap
+    // entirely and the guard's length check never saw it. Appended here
+    // instead so the guard's decision to trim memories/lessons/preferences/
+    // user-model/archival actually accounts for the real total size.
+    // extraContext itself is intentionally NOT in the trim list below: it's
+    // context the caller attached for this specific task (unlike the
+    // general-purpose sections that follow), so it stays protected the same
+    // way soul/CORE/active-project do.
+    if (context.extraContext) {
+      prompt += '\n' + context.extraContext;
+    }
+
     // ── Total budget guard (Chunk B2) ──
     // buildSystemPrompt had NO total size cap, so a large book-bible + lessons +
     // preferences + user-model + archival could bloat context unbounded. Apply a
     // SOFT total-char cap. When exceeded, drop the LOWEST-priority already-capped
     // sections first, in a fixed order. We NEVER trim: soul, the CORE block, the
-    // injection/security caution (appended by the caller), or the active-project
-    // section. Each trim target is the exact literal substring we concatenated,
-    // so removal is precise and cannot corrupt neighbouring sections.
+    // injection/security caution (appended by the caller), the active-project
+    // section, or extraContext (see above). Each trim target is the exact
+    // literal substring we concatenated, so removal is precise and cannot
+    // corrupt neighbouring sections.
+    //
+    // 'memories' trims FIRST: it's the least-curated section (a
+    // relevance-ranked keyword match over book-bible files, capped at 8,000
+    // chars in MemoryService.getRelevant but previously excluded from this
+    // list entirely — meaning the guard could never actually reach the cap
+    // when memory dominated it) versus lessons/preferences/user-model, which
+    // are explicit, curated signals worth keeping longer.
     prompt = this.applyTotalBudgetGuard(prompt, [
+      { name: 'memories', block: relevantMemoryBlock },
       { name: 'lessons', block: lessonsBlock },
       { name: 'preferences', block: preferencesBlock },
       { name: 'user-model', block: userModelBlock },

--- a/gateway/src/services/project-templates.ts
+++ b/gateway/src/services/project-templates.ts
@@ -31,6 +31,24 @@ export type ProjectType =
   | 'pipeline'
   | 'custom';
 
+// Phase markers used across novel-pipeline / book-production steps. Also the
+// keys reviewGates and the gate template defaults are indexed by.
+export type PhaseName =
+  | 'premise'
+  | 'bible'
+  | 'outline'
+  | 'writing'
+  | 'revision'
+  | 'revision_apply'
+  | 'polish'
+  | 'assembly';
+
+export interface ProjectContext extends Record<string, any> {
+  // Per-phase override of the locked gate defaults (see GATED_PHASES_DEFAULT).
+  // Missing phase ⇒ fall through to the template default.
+  reviewGates?: Partial<Record<PhaseName, boolean>>;
+}
+
 export interface Project {
   id: string;
   type: ProjectType;
@@ -42,11 +60,23 @@ export interface Project {
   createdAt: string;
   updatedAt: string;
   completedAt?: string;
-  context: Record<string, any>;
+  context: ProjectContext;
   personaId?: string;     // Author persona assigned to this project
   preferredProvider?: string; // Override AI provider: 'gemini' | 'claude' | 'openai' | 'deepseek' | 'ollama' | null (auto)
   pipelineId?: string;    // Parent pipeline ID (if part of a pipeline)
   pipelinePhase?: number; // Phase order within pipeline (1-6)
+}
+
+// State of a step's review gate. 'open' = awaiting a human decision, and
+// unlike ConfirmationGateService requests, an open gate never expires — the
+// pipeline simply waits. 'approved'/'rejected' are terminal.
+export type GateState = 'open' | 'approved' | 'rejected';
+
+export interface StepGate {
+  state: GateState;
+  openedAt: string;      // ISO timestamp — set when the step reaches completion gated
+  decidedAt?: string;    // ISO timestamp — set when a human approves/rejects
+  decidedVersion?: number; // The doc-versions.ts version number the decision applies to
 }
 
 export interface ProjectStep {
@@ -56,7 +86,7 @@ export interface ProjectStep {
   toolSuggestion?: string; // Author OS tool to use
   taskType: string;        // AI router task type (for tier routing)
   prompt: string;          // The prompt to send to AI
-  status: 'pending' | 'active' | 'completed' | 'skipped' | 'failed';
+  status: 'pending' | 'active' | 'completed' | 'awaiting_review' | 'skipped' | 'failed';
   result?: string;
   error?: string;
   // Novel pipeline fields:
@@ -70,6 +100,9 @@ export interface ProjectStep {
   // (identical to the pre-conductor behavior). Present ⇒ the supervisor loop
   // may dispatch independent steps concurrently.
   dependsOn?: string[];
+  // ── Review gate (see resolveStepGate / applyStepCompletion below) ──
+  gateEnabled?: boolean;  // Per-step override — beats context.reviewGates and the template default.
+  gate?: StepGate;        // Present once this step's gate has been opened at least once.
 }
 
 export interface NovelPipelineConfig {
@@ -84,6 +117,74 @@ export interface NovelPipelineConfig {
   targetWordsPerChapter?: number; // default 3000
   protagonistName?: string;
   antagonistName?: string;
+}
+
+// ═══════════════════════════════════════════════════════════
+// Gate state machine
+//
+// Every step persists a .md result, so every step is gateable in principle —
+// there is no gateable/non-gateable split. What keeps this manageable is the
+// locked per-phase default below: steps in a "planning" phase (premise/bible/
+// outline) gate for human review by default; downstream production phases
+// (writing/revision/polish/assembly) complete automatically, as they do
+// today. Callers can override per-step (gateEnabled) or per-phase, per-project
+// (context.reviewGates) without touching the locked defaults.
+//
+// This module intentionally stays pure/data-only (no engine, no I/O, no
+// expiry) — it mirrors the status-enum/audit-trail discipline of
+// ConfirmationGateService (confirmation-gate.ts) WITHOUT reusing that class,
+// since a review gate must never expire the way a 24h confirmation request
+// does.
+// ═══════════════════════════════════════════════════════════
+
+/** Phases gated for human review unless a step/project override says otherwise. */
+export const GATED_PHASES_DEFAULT: ReadonlySet<PhaseName> = new Set<PhaseName>([
+  'premise', 'bible', 'outline',
+]);
+
+/**
+ * Resolve whether a step gates on completion (enters 'awaiting_review'
+ * instead of 'completed'). Resolution order:
+ *   1. step.gateEnabled       — explicit per-step override, wins outright.
+ *   2. context.reviewGates[phase] — per-project, per-phase override.
+ *   3. GATED_PHASES_DEFAULT   — locked template default.
+ * A step with no phase (e.g. custom single-step projects, or template steps
+ * that never set `phase`) only gates via an explicit override — the locked
+ * default never applies to a phase-less step.
+ */
+export function resolveStepGate(step: ProjectStep, project: Project): boolean {
+  if (typeof step.gateEnabled === 'boolean') return step.gateEnabled;
+
+  const phase = step.phase as PhaseName | undefined;
+  if (!phase) return false;
+
+  const reviewGates = project.context?.reviewGates;
+  const override = reviewGates?.[phase];
+  if (typeof override === 'boolean') return override;
+
+  return GATED_PHASES_DEFAULT.has(phase);
+}
+
+/**
+ * Apply step completion under the gate state machine. Mutates `step` in
+ * place. A gated step opens its review gate (status -> 'awaiting_review',
+ * gate.state -> 'open') instead of completing. An ungated step completes
+ * exactly as it always has — same two field writes, nothing added.
+ */
+export function applyStepCompletion(
+  step: ProjectStep,
+  project: Project,
+  result: string,
+  now: string = new Date().toISOString(),
+): void {
+  if (resolveStepGate(step, project)) {
+    step.status = 'awaiting_review';
+    step.result = result;
+    step.gate = { state: 'open', openedAt: now };
+  } else {
+    step.status = 'completed';
+    step.result = result;
+  }
 }
 
 // ═══════════════════════════════════════════════════════════

--- a/gateway/src/services/project-templates.ts
+++ b/gateway/src/services/project-templates.ts
@@ -79,6 +79,20 @@ export interface StepGate {
   decidedVersion?: number; // The doc-versions.ts version number the decision applies to
 }
 
+// Marks a completed step as stale because an upstream step it transitively
+// depends on (via dependsOn) gained a new version after having already been
+// approved. `dirty` is orthogonal to `status` — a dirty step is still
+// `completed`; this is NOT a new status-union member. Set by
+// dependency-graph.ts, consumed by the M4 severity classifier (dirty-step-
+// classifier.ts), which fills in `severity`.
+export interface DirtyMarker {
+  causeStepId: string;      // the upstream step whose new version triggered this
+  causeVersionFrom: number; // the doc-versions.ts version the cause step was on when approved
+  causeVersionTo: number;   // the new doc-versions.ts version the cause step just gained
+  severity?: 'high' | 'low' | 'none'; // left undefined until M4 classifies it
+  markedAt: string;         // ISO timestamp — when this dependent was marked dirty
+}
+
 export interface ProjectStep {
   id: string;
   label: string;
@@ -103,6 +117,11 @@ export interface ProjectStep {
   // ── Review gate (see resolveStepGate / applyStepCompletion below) ──
   gateEnabled?: boolean;  // Per-step override — beats context.reviewGates and the template default.
   gate?: StepGate;        // Present once this step's gate has been opened at least once.
+  // ── Dirty tracking (see dependency-graph.ts) ──
+  // Present when an already-approved step this one transitively depends on
+  // gained a new version. Orthogonal to `status` (see DirtyMarker). Cleared
+  // by whatever re-approves/re-reviews this step (outside this module's scope).
+  dirty?: DirtyMarker;
 }
 
 export interface NovelPipelineConfig {

--- a/gateway/src/services/projects-tiered.test.ts
+++ b/gateway/src/services/projects-tiered.test.ts
@@ -231,6 +231,7 @@ describe('StepExecutor full-manuscript allowlist (Chunk B1)', () => {
     getProject: () => undefined,
     completeStep: () => null,
     completeStepBare: () => {},
+    openStepGate: () => {},
     activateStep: () => null,
     failStep: () => {},
     buildProjectContext: async () => '',

--- a/gateway/src/services/projects.ts
+++ b/gateway/src/services/projects.ts
@@ -37,6 +37,7 @@ import {
   buildNovelPipelineSteps,
   buildBookProductionSteps,
   deriveDependencies,
+  applyStepCompletion,
   type Project,
   type ProjectStep,
   type ProjectType,
@@ -138,6 +139,7 @@ export class ProjectEngine {
       getProject: (id) => this.getProject(id),
       completeStep: (projectId, stepId, result) => this.completeStep(projectId, stepId, result),
       completeStepBare: (projectId, stepId, result) => this.completeStepBare(projectId, stepId, result),
+      openStepGate: (projectId, stepId, result) => this.openStepGate(projectId, stepId, result),
       activateStep: (projectId, stepId) => this.activateStep(projectId, stepId),
       failStep: (projectId, stepId, error) => this.failStep(projectId, stepId, error),
       buildProjectContext: (project, step) => this.buildProjectContext(project, step),
@@ -680,6 +682,31 @@ Description: ${description}`;
         logger.debug('project-completion hook dispatch failed', err);
       }
     }
+    this.persistState();
+  }
+
+  /**
+   * Open a step's review gate instead of completing it (M1.3 — ALP-1557).
+   * Called by the executor in place of completeStep/completeStepBare when
+   * resolveStepGate() (project-templates.ts) says the step gates on
+   * completion. Delegates the state transition to applyStepCompletion — the
+   * same pure function the gate state machine's own tests cover — so this
+   * is just persistence + timestamp bookkeeping around it.
+   *
+   * Deliberately does NOT recompute "remaining steps" / project-completion —
+   * an awaiting_review step is neither pending/active nor completed/skipped,
+   * so it simply falls out of both checks: dependents stay blocked (conductor
+   * ready-set) and the project is never mis-marked complete around it.
+   */
+  openStepGate(projectId: string, stepId: string, result: string): void {
+    const project = this.projects.get(projectId);
+    if (!project) return;
+    const step = project.steps.find(s => s.id === stepId);
+    if (!step) return;
+
+    applyStepCompletion(step, project, result);
+
+    project.updatedAt = new Date().toISOString();
     this.persistState();
   }
 

--- a/gateway/src/services/projects.ts
+++ b/gateway/src/services/projects.ts
@@ -42,6 +42,7 @@ import {
   type ProjectStep,
   type ProjectType,
   type NovelPipelineConfig,
+  type PhaseName,
 } from './project-templates.js';
 import {
   StepExecutor,
@@ -50,6 +51,7 @@ import {
   type StepServices,
   type ExecuteStepOptions,
 } from './step-executor.js';
+import { markDependentsDirty } from './dependency-graph.js';
 
 const log = logger.child('[projects]');
 
@@ -918,6 +920,128 @@ Description: ${description}`;
       | { ok: false; kind: 'error'; error: string; project: Project }
     > {
     return this.stepExecutor.executeStepWithRetry(projectId);
+  }
+
+  /**
+   * Rerun an awaiting_review step with reviewer feedback (M1.5 — ALP-1559,
+   * POST .../revise). Thin delegate — see StepExecutor.reviseStep for the
+   * version-append + gate-reopen behavior.
+   */
+  async reviseStep(projectId: string, stepId: string, feedback: string, workspaceDir: string) {
+    return this.stepExecutor.reviseStep(projectId, stepId, feedback, workspaceDir);
+  }
+
+  /**
+   * Decide a step's open review gate (M1.5 — ALP-1559, POST .../approve).
+   * 'approved' completes the step exactly as completeStepBare would have if
+   * it hadn't gated — unblocking dependents on the conductor's next tick —
+   * and, if this approval bumps the step past the version it was previously
+   * approved at, marks every downstream completed step dirty (M1.4 —
+   * dependency-graph.ts) so reviewers know what needs a second look.
+   * Returns null if the project/step doesn't exist or the step isn't
+   * currently awaiting review.
+   */
+  decideStepGate(
+    projectId: string,
+    stepId: string,
+    decision: 'approved' | 'rejected',
+    currentVersion?: number,
+  ): ProjectStep | null {
+    const project = this.projects.get(projectId);
+    if (!project) return null;
+    const step = project.steps.find(s => s.id === stepId);
+    if (!step || step.status !== 'awaiting_review' || !step.gate) return null;
+
+    const previousDecidedVersion = step.gate.decidedVersion;
+    const now = new Date().toISOString();
+    step.gate = {
+      ...step.gate,
+      state: decision,
+      decidedAt: now,
+      ...(decision === 'approved' ? { decidedVersion: currentVersion } : {}),
+    };
+
+    if (decision === 'approved') {
+      this.completeStepBare(projectId, stepId, step.result || '');
+      if (
+        typeof previousDecidedVersion === 'number' &&
+        typeof currentVersion === 'number' &&
+        currentVersion > previousDecidedVersion
+      ) {
+        const marked = markDependentsDirty(project.steps, stepId, previousDecidedVersion, currentVersion, now);
+        if (marked.length > 0) this.persistState();
+      }
+    } else {
+      project.updatedAt = now;
+      this.persistState();
+    }
+    return step;
+  }
+
+  /**
+   * Record a manually-saved version's content on the step itself (M1.5 —
+   * ALP-1559, POST .../versions). The caller has already appended the
+   * immutable version + rewritten the canonical file on disk — this just
+   * keeps in-memory step.result (what buildProjectContext/downstream steps
+   * read) in sync and persists project state.
+   */
+  saveStepResult(projectId: string, stepId: string, content: string): ProjectStep | null {
+    const project = this.projects.get(projectId);
+    if (!project) return null;
+    const step = project.steps.find(s => s.id === stepId);
+    if (!step) return null;
+    step.result = content;
+    project.updatedAt = new Date().toISOString();
+    this.persistState();
+    return step;
+  }
+
+  /**
+   * Clear a step's dirty marker (M1.5 — ALP-1559, POST .../clean). Orthogonal
+   * to status/gate — this only acknowledges the downstream-impact flag from
+   * dependency-graph.ts, it doesn't re-run or re-approve anything.
+   */
+  markStepClean(projectId: string, stepId: string): ProjectStep | null {
+    const project = this.projects.get(projectId);
+    if (!project) return null;
+    const step = project.steps.find(s => s.id === stepId);
+    if (!step) return null;
+    delete step.dirty;
+    project.updatedAt = new Date().toISOString();
+    this.persistState();
+    return step;
+  }
+
+  /**
+   * Update review-gate configuration for a project (M1.5 — ALP-1559, PATCH
+   * /api/projects/:id/gates): per-phase overrides on project.context.reviewGates
+   * and/or per-step gateEnabled overrides. Both are merged shallowly into the
+   * existing config — omitted keys are left untouched.
+   */
+  updateReviewGates(
+    projectId: string,
+    updates: { reviewGates?: Partial<Record<PhaseName, boolean>>; stepGateOverrides?: Record<string, boolean | null> },
+  ): Project | null {
+    const project = this.projects.get(projectId);
+    if (!project) return null;
+
+    if (updates.reviewGates) {
+      project.context = project.context || {};
+      project.context.reviewGates = { ...(project.context.reviewGates || {}), ...updates.reviewGates };
+    }
+
+    if (updates.stepGateOverrides) {
+      for (const [stepId, gateEnabled] of Object.entries(updates.stepGateOverrides)) {
+        const step = project.steps.find(s => s.id === stepId);
+        if (!step) continue;
+        if (gateEnabled === null) delete step.gateEnabled;
+        else step.gateEnabled = gateEnabled;
+      }
+    }
+
+    project.updatedAt = new Date().toISOString();
+    this.persistState();
+    return project;
   }
 
   /**

--- a/gateway/src/services/step-executor-conductor.test.ts
+++ b/gateway/src/services/step-executor-conductor.test.ts
@@ -28,6 +28,7 @@ import {
   deriveDependencies,
   buildBookProductionSteps,
   buildNovelPipelineSteps,
+  applyStepCompletion,
   type Project,
   type ProjectStep,
 } from './project-templates.js';
@@ -98,6 +99,10 @@ function makeEngine(project: Project): EnginePort {
       if (s) { s.status = 'completed'; s.result = result; }
       const remaining = project.steps.filter(x => x.status === 'pending' || x.status === 'active');
       if (remaining.length === 0 && project.status !== 'paused') project.status = 'completed';
+    },
+    openStepGate: (_pid, sid, result) => {
+      const s = project.steps.find(x => x.id === sid);
+      if (s) applyStepCompletion(s, project, result);
     },
     activateStep: (_pid, sid) => {
       const s = project.steps.find(x => x.id === sid);
@@ -415,6 +420,35 @@ describe('conductor loop', () => {
 
     expect(summaryOrder).toEqual(['w1', 'w2', 'w3']);
   });
+
+  // ── M1.3 — ALP-1557: gate-blocking ──
+  it('a gated step opens its review gate and blocks only its own dependent branch; parallel siblings keep completing', async () => {
+    // A gates on completion; B depends on A; C is fully independent.
+    const project = makeProject('gate', [
+      { id: 'A', dependsOn: [], gateEnabled: true },
+      { id: 'B', dependsOn: ['A'] },
+      { id: 'C', dependsOn: [] },
+    ]);
+    const timeline: TimelineEvent[] = [];
+    const handler = makeHandler({ A: {}, B: {}, C: {} }, timeline);
+
+    const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
+    const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
+
+    const byId = Object.fromEntries(project.steps.map(s => [s.id, s]));
+    expect(byId.A.status).toBe('awaiting_review');
+    expect(byId.A.gate).toEqual({ state: 'open', openedAt: expect.any(String) });
+    // B never became ready — depsSatisfied() requires 'completed'/'skipped',
+    // and 'awaiting_review' is neither. No new scheduling logic needed for this.
+    expect(byId.B.status).toBe('pending');
+    // C is on an independent branch and completes normally.
+    expect(byId.C.status).toBe('completed');
+
+    expect(results.find(r => r.step === 'A')).toMatchObject({ success: true, gated: true });
+    expect(results.find(r => r.step === 'B')).toBeUndefined(); // never dispatched
+    // The project can't be "done" while B is still blocked behind the gate.
+    expect(project.status).not.toBe('completed');
+  });
 });
 
 // ═══════════════════════════════════════════════════════════
@@ -468,5 +502,33 @@ describe('legacy projects (no dependsOn) run strictly sequentially', () => {
 
     expect(results.map(r => r.step)).toEqual(['F1', 'F2']); // stopped at the failure
     expect(project.steps.find(s => s.id === 'F3')!.status).toBe('pending'); // never activated after the halt
+  });
+
+  // ── M1.3 — ALP-1557: gate-blocking ──
+  it('halts cleanly at a gate — NOT as a failure — and never activates the next step', async () => {
+    const project = makeProject('legacy-gate', [
+      { id: 'G1' }, { id: 'G2', gateEnabled: true }, { id: 'G3' },
+    ]);
+    project.steps.forEach(s => { delete (s as any).dependsOn; });
+    project.steps[0].status = 'active';
+
+    const timeline: TimelineEvent[] = [];
+    const handler = makeHandler({ G1: {}, G2: {}, G3: {} }, timeline);
+
+    const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
+    const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
+
+    // Halted right after the gate — G3 never ran.
+    expect(results.map(r => r.step)).toEqual(['G1', 'G2']);
+    // A gate is NOT an error: every pushed result is success:true, and G2 is
+    // flagged gated so callers can tell "halted" apart from "failed".
+    expect(results.every(r => r.success)).toBe(true);
+    expect(results.find(r => r.step === 'G2')).toMatchObject({ success: true, gated: true });
+
+    const byId = Object.fromEntries(project.steps.map(s => [s.id, s]));
+    expect(byId.G1.status).toBe('completed');
+    expect(byId.G2.status).toBe('awaiting_review');
+    expect(byId.G3.status).toBe('pending'); // never activated after the halt
+    expect(project.status).not.toBe('completed');
   });
 });

--- a/gateway/src/services/step-executor-conductor.test.ts
+++ b/gateway/src/services/step-executor-conductor.test.ts
@@ -12,7 +12,7 @@
  * EnginePort double manages step status transitions.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -72,7 +72,7 @@ function makeHandler(
     if (liveCounter) { liveCounter.cur++; liveCounter.max = Math.max(liveCounter.max, liveCounter.cur); }
     timeline.push({ id, event: 'start', t: Date.now() });
     cfg.onStart?.();
-    await new Promise(r => setTimeout(r, cfg.delayMs ?? 15));
+    await vi.advanceTimersByTimeAsync(cfg.delayMs ?? 15);
     timeline.push({ id, event: 'end', t: Date.now() });
     if (liveCounter) liveCounter.cur--;
     if (cfg.fail) { respond('[AI provider failure] simulated failure'); return; }
@@ -241,184 +241,219 @@ describe('deriveDependencies', () => {
 
 describe('conductor loop', () => {
   it('runs independent steps concurrently while chapters stay sequential', async () => {
-    // write1 → write2 (chapter continuity); polish1 hangs off write1.
-    const project = makeProject('cc', [
-      { id: 'w1', skill: 'write', chapterNumber: 1, dependsOn: [] },
-      { id: 'w2', skill: 'write', chapterNumber: 2, dependsOn: ['w1'] },
-      { id: 'p1', phase: 'polish', skill: 'revise', chapterNumber: 1, dependsOn: ['w1'] },
-    ]);
-    const timeline: TimelineEvent[] = [];
-    const handler = makeHandler({
-      w1: { delayMs: 20 }, w2: { delayMs: 60 }, p1: { delayMs: 60 },
-    }, timeline);
+    vi.useFakeTimers();
+    try {
+      // write1 → write2 (chapter continuity); polish1 hangs off write1.
+      const project = makeProject('cc', [
+        { id: 'w1', skill: 'write', chapterNumber: 1, dependsOn: [] },
+        { id: 'w2', skill: 'write', chapterNumber: 2, dependsOn: ['w1'] },
+        { id: 'p1', phase: 'polish', skill: 'revise', chapterNumber: 1, dependsOn: ['w1'] },
+      ]);
+      const timeline: TimelineEvent[] = [];
+      const handler = makeHandler({
+        w1: { delayMs: 20 }, w2: { delayMs: 60 }, p1: { delayMs: 60 },
+      }, timeline);
 
-    const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
-    const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
+      const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
+      const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
 
-    expect(results.every(r => r.success)).toBe(true);
-    expect(results.length).toBe(3);
+      expect(results.every(r => r.success)).toBe(true);
+      expect(results.length).toBe(3);
 
-    const w1i = interval(timeline, 'w1');
-    const w2i = interval(timeline, 'w2');
-    const p1i = interval(timeline, 'p1');
+      const w1i = interval(timeline, 'w1');
+      const w2i = interval(timeline, 'w2');
+      const p1i = interval(timeline, 'p1');
 
-    // Chapters sequential: write2 starts only after write1 ends.
-    expect(w2i.start).toBeGreaterThanOrEqual(w1i.end);
-    // Independent branch: polish1 overlaps write2 (they run concurrently).
-    expect(overlaps(p1i, w2i)).toBe(true);
-    expect(project.status).toBe('completed');
+      // Chapters sequential: write2 starts only after write1 ends.
+      expect(w2i.start).toBeGreaterThanOrEqual(w1i.end);
+      // Independent branch: polish1 overlaps write2 (they run concurrently).
+      expect(overlaps(p1i, w2i)).toBe(true);
+      expect(project.status).toBe('completed');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('a failed step blocks only its dependents; independent branches continue', async () => {
-    // A → B → D  and  A → C. B fails, so only D is blocked.
-    const project = makeProject('fail', [
-      { id: 'A', dependsOn: [] },
-      { id: 'B', dependsOn: ['A'] },
-      { id: 'C', dependsOn: ['A'] },
-      { id: 'D', dependsOn: ['B'] },
-    ]);
-    const timeline: TimelineEvent[] = [];
-    const handler = makeHandler({
-      A: {}, B: { fail: true }, C: {}, D: {},
-    }, timeline);
+    vi.useFakeTimers();
+    try {
+      // A → B → D  and  A → C. B fails, so only D is blocked.
+      const project = makeProject('fail', [
+        { id: 'A', dependsOn: [] },
+        { id: 'B', dependsOn: ['A'] },
+        { id: 'C', dependsOn: ['A'] },
+        { id: 'D', dependsOn: ['B'] },
+      ]);
+      const timeline: TimelineEvent[] = [];
+      const handler = makeHandler({
+        A: {}, B: { fail: true }, C: {}, D: {},
+      }, timeline);
 
-    const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
-    const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
+      const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
+      const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
 
-    const byId = Object.fromEntries(project.steps.map(s => [s.id, s.status]));
-    expect(byId.A).toBe('completed');
-    expect(byId.B).toBe('failed');
-    expect(byId.C).toBe('completed');   // independent branch ran despite B failing
-    expect(byId.D).toBe('pending');     // dependent of B never became ready
-    // D never executed.
-    expect(results.find(r => r.step === 'D')).toBeUndefined();
-    expect(project.status).not.toBe('completed'); // D still outstanding
+      const byId = Object.fromEntries(project.steps.map(s => [s.id, s.status]));
+      expect(byId.A).toBe('completed');
+      expect(byId.B).toBe('failed');
+      expect(byId.C).toBe('completed');   // independent branch ran despite B failing
+      expect(byId.D).toBe('pending');     // dependent of B never became ready
+      // D never executed.
+      expect(results.find(r => r.step === 'D')).toBeUndefined();
+      expect(project.status).not.toBe('completed'); // D still outstanding
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('pause stops NEW dispatches but lets in-flight steps finish', async () => {
-    // A, B independent (both dispatched at concurrency 2); C independent, would
-    // be dispatched next. A pauses the project mid-flight → C must NOT start.
-    const project = makeProject('pause', [
-      { id: 'A', dependsOn: [] },
-      { id: 'B', dependsOn: [] },
-      { id: 'C', dependsOn: [] },
-    ]);
-    project.context = { conductorConcurrency: 2 };
-    const timeline: TimelineEvent[] = [];
-    const handler = makeHandler({
-      A: { delayMs: 30, onStart: () => { project.status = 'paused'; } },
-      B: { delayMs: 30 },
-      C: { delayMs: 30 },
-    }, timeline);
+    vi.useFakeTimers();
+    try {
+      // A, B independent (both dispatched at concurrency 2); C independent, would
+      // be dispatched next. A pauses the project mid-flight → C must NOT start.
+      const project = makeProject('pause', [
+        { id: 'A', dependsOn: [] },
+        { id: 'B', dependsOn: [] },
+        { id: 'C', dependsOn: [] },
+      ]);
+      project.context = { conductorConcurrency: 2 };
+      const timeline: TimelineEvent[] = [];
+      const handler = makeHandler({
+        A: { delayMs: 30, onStart: () => { project.status = 'paused'; } },
+        B: { delayMs: 30 },
+        C: { delayMs: 30 },
+      }, timeline);
 
-    const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
-    const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
+      const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
+      const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
 
-    const byId = Object.fromEntries(project.steps.map(s => [s.id, s.status]));
-    // In-flight A and B finished…
-    expect(byId.A).toBe('completed');
-    expect(byId.B).toBe('completed');
-    // …but the paused project stopped C from ever dispatching.
-    expect(byId.C).toBe('pending');
-    expect(results.find(r => r.step === 'C')).toBeUndefined();
-    expect(project.status).toBe('paused');
+      const byId = Object.fromEntries(project.steps.map(s => [s.id, s.status]));
+      // In-flight A and B finished…
+      expect(byId.A).toBe('completed');
+      expect(byId.B).toBe('completed');
+      // …but the paused project stopped C from ever dispatching.
+      expect(byId.C).toBe('pending');
+      expect(results.find(r => r.step === 'C')).toBeUndefined();
+      expect(project.status).toBe('paused');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('respects the concurrency cap (project override)', async () => {
-    const project = makeProject('cap', [
-      { id: 's1', dependsOn: [] }, { id: 's2', dependsOn: [] },
-      { id: 's3', dependsOn: [] }, { id: 's4', dependsOn: [] },
-      { id: 's5', dependsOn: [] },
-    ]);
-    project.context = { conductorConcurrency: 2 };
-    const timeline: TimelineEvent[] = [];
-    const live = { cur: 0, max: 0 };
-    const handler = makeHandler(
-      Object.fromEntries(project.steps.map(s => [s.id, { delayMs: 25 }])),
-      timeline, live,
-    );
+    vi.useFakeTimers();
+    try {
+      const project = makeProject('cap', [
+        { id: 's1', dependsOn: [] }, { id: 's2', dependsOn: [] },
+        { id: 's3', dependsOn: [] }, { id: 's4', dependsOn: [] },
+        { id: 's5', dependsOn: [] },
+      ]);
+      project.context = { conductorConcurrency: 2 };
+      const timeline: TimelineEvent[] = [];
+      const live = { cur: 0, max: 0 };
+      const handler = makeHandler(
+        Object.fromEntries(project.steps.map(s => [s.id, { delayMs: 25 }])),
+        timeline, live,
+      );
 
-    const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
-    await exec.autoExecuteLoop(project.id, { workspaceDir });
+      const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
+      await exec.autoExecuteLoop(project.id, { workspaceDir });
 
-    expect(live.max).toBe(2); // never more than 2 concurrent AI calls
+      expect(live.max).toBe(2); // never more than 2 concurrent AI calls
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('clamps an out-of-range concurrency to the max of 3', async () => {
-    const project = makeProject('clamp', [
-      { id: 's1', dependsOn: [] }, { id: 's2', dependsOn: [] },
-      { id: 's3', dependsOn: [] }, { id: 's4', dependsOn: [] },
-      { id: 's5', dependsOn: [] },
-    ]);
-    project.context = { conductorConcurrency: 99 };
-    const timeline: TimelineEvent[] = [];
-    const live = { cur: 0, max: 0 };
-    const handler = makeHandler(
-      Object.fromEntries(project.steps.map(s => [s.id, { delayMs: 25 }])),
-      timeline, live,
-    );
+    vi.useFakeTimers();
+    try {
+      const project = makeProject('clamp', [
+        { id: 's1', dependsOn: [] }, { id: 's2', dependsOn: [] },
+        { id: 's3', dependsOn: [] }, { id: 's4', dependsOn: [] },
+        { id: 's5', dependsOn: [] },
+      ]);
+      project.context = { conductorConcurrency: 99 };
+      const timeline: TimelineEvent[] = [];
+      const live = { cur: 0, max: 0 };
+      const handler = makeHandler(
+        Object.fromEntries(project.steps.map(s => [s.id, { delayMs: 25 }])),
+        timeline, live,
+      );
 
-    const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
-    await exec.autoExecuteLoop(project.id, { workspaceDir });
+      const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
+      await exec.autoExecuteLoop(project.id, { workspaceDir });
 
-    expect(live.max).toBe(3);
+      expect(live.max).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('processes context-engine hooks serially (never concurrently) even on simultaneous completions', async () => {
-    // Three canonical steps ready at once: one chapter write + two bible steps.
-    // Their AI calls run concurrently, but the context-engine hooks must NOT.
-    const project = makeProject('hooks', [
-      { id: 'w1', skill: 'write', chapterNumber: 1, dependsOn: [] },
-      { id: 'b1', label: 'World bible', dependsOn: [] },
-      { id: 'b2', label: 'Character bible', dependsOn: [] },
-    ]);
-    project.type = 'book-bible';
-    project.context = { conductorConcurrency: 3 };
+    vi.useFakeTimers();
+    try {
+      // Three canonical steps ready at once: one chapter write + two bible steps.
+      // Their AI calls run concurrently, but the context-engine hooks must NOT.
+      const project = makeProject('hooks', [
+        { id: 'w1', skill: 'write', chapterNumber: 1, dependsOn: [] },
+        { id: 'b1', label: 'World bible', dependsOn: [] },
+        { id: 'b2', label: 'Character bible', dependsOn: [] },
+      ]);
+      project.type = 'book-bible';
+      project.context = { conductorConcurrency: 3 };
 
-    const hookLive = { cur: 0, max: 0 };
-    const hookOrder: string[] = [];
-    const contextEngine = {
-      async generateSummary(_pid: string, stepId: string) {
-        hookLive.cur++; hookLive.max = Math.max(hookLive.max, hookLive.cur);
-        hookOrder.push(stepId);
-        await new Promise(r => setTimeout(r, 15));
-        hookLive.cur--;
-      },
-      async extractEntities() { /* no-op */ },
-    };
+      const hookLive = { cur: 0, max: 0 };
+      const hookOrder: string[] = [];
+      const contextEngine = {
+        async generateSummary(_pid: string, stepId: string) {
+          hookLive.cur++; hookLive.max = Math.max(hookLive.max, hookLive.cur);
+          hookOrder.push(stepId);
+          await vi.advanceTimersByTimeAsync(15);
+          hookLive.cur--;
+        },
+        async extractEntities() { /* no-op */ },
+      };
 
-    const timeline: TimelineEvent[] = [];
-    const handler = makeHandler({
-      w1: { delayMs: 10 }, b1: { delayMs: 10 }, b2: { delayMs: 10 },
-    }, timeline);
+      const timeline: TimelineEvent[] = [];
+      const handler = makeHandler({
+        w1: { delayMs: 10 }, b1: { delayMs: 10 }, b2: { delayMs: 10 },
+      }, timeline);
 
-    const exec = new StepExecutor(makeEngine(project), makeDeps(handler, {}, contextEngine));
-    await exec.autoExecuteLoop(project.id, { workspaceDir });
+      const exec = new StepExecutor(makeEngine(project), makeDeps(handler, {}, contextEngine));
+      await exec.autoExecuteLoop(project.id, { workspaceDir });
 
-    // Hooks were serialized despite the three steps completing near-simultaneously.
-    expect(hookLive.max).toBe(1);
-    expect(hookOrder.length).toBe(3);
+      // Hooks were serialized despite the three steps completing near-simultaneously.
+      expect(hookLive.max).toBe(1);
+      expect(hookOrder.length).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('chapter WRITE hooks fire in ascending chapter order', async () => {
-    // Strictly-sequential chapter chain → summaries recorded in chapter order.
-    const project = makeProject('order', [
-      { id: 'w1', skill: 'write', chapterNumber: 1, dependsOn: [] },
-      { id: 'w2', skill: 'write', chapterNumber: 2, dependsOn: ['w1'] },
-      { id: 'w3', skill: 'write', chapterNumber: 3, dependsOn: ['w2'] },
-    ]);
-    const summaryOrder: string[] = [];
-    const contextEngine = {
-      async generateSummary(_pid: string, stepId: string) { summaryOrder.push(stepId); },
-      async extractEntities() { /* no-op */ },
-    };
-    const timeline: TimelineEvent[] = [];
-    const handler = makeHandler({ w1: {}, w2: {}, w3: {} }, timeline);
+    vi.useFakeTimers();
+    try {
+      // Strictly-sequential chapter chain → summaries recorded in chapter order.
+      const project = makeProject('order', [
+        { id: 'w1', skill: 'write', chapterNumber: 1, dependsOn: [] },
+        { id: 'w2', skill: 'write', chapterNumber: 2, dependsOn: ['w1'] },
+        { id: 'w3', skill: 'write', chapterNumber: 3, dependsOn: ['w2'] },
+      ]);
+      const summaryOrder: string[] = [];
+      const contextEngine = {
+        async generateSummary(_pid: string, stepId: string) { summaryOrder.push(stepId); },
+        async extractEntities() { /* no-op */ },
+      };
+      const timeline: TimelineEvent[] = [];
+      const handler = makeHandler({ w1: {}, w2: {}, w3: {} }, timeline);
 
-    const exec = new StepExecutor(makeEngine(project), makeDeps(handler, {}, contextEngine));
-    await exec.autoExecuteLoop(project.id, { workspaceDir });
+      const exec = new StepExecutor(makeEngine(project), makeDeps(handler, {}, contextEngine));
+      await exec.autoExecuteLoop(project.id, { workspaceDir });
 
-    expect(summaryOrder).toEqual(['w1', 'w2', 'w3']);
+      expect(summaryOrder).toEqual(['w1', 'w2', 'w3']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // ── M1.3 — ALP-1557: gate-blocking ──
@@ -457,51 +492,61 @@ describe('conductor loop', () => {
 
 describe('legacy projects (no dependsOn) run strictly sequentially', () => {
   it('executes steps one at a time in declared order — no overlap', async () => {
-    // No dependsOn on any step → hasDeps=false → legacy loop.
-    const project = makeProject('legacy', [
-      { id: 'L1' }, { id: 'L2' }, { id: 'L3' },
-    ]);
-    // Strip dependsOn to simulate a pre-conductor persisted project.
-    project.steps.forEach(s => { delete (s as any).dependsOn; });
-    // Route pre-activates the first step in the sequential model.
-    project.steps[0].status = 'active';
+    vi.useFakeTimers();
+    try {
+      // No dependsOn on any step → hasDeps=false → legacy loop.
+      const project = makeProject('legacy', [
+        { id: 'L1' }, { id: 'L2' }, { id: 'L3' },
+      ]);
+      // Strip dependsOn to simulate a pre-conductor persisted project.
+      project.steps.forEach(s => { delete (s as any).dependsOn; });
+      // Route pre-activates the first step in the sequential model.
+      project.steps[0].status = 'active';
 
-    const timeline: TimelineEvent[] = [];
-    const live = { cur: 0, max: 0 };
-    const handler = makeHandler({
-      L1: { delayMs: 20 }, L2: { delayMs: 20 }, L3: { delayMs: 20 },
-    }, timeline, live);
+      const timeline: TimelineEvent[] = [];
+      const live = { cur: 0, max: 0 };
+      const handler = makeHandler({
+        L1: { delayMs: 20 }, L2: { delayMs: 20 }, L3: { delayMs: 20 },
+      }, timeline, live);
 
-    const exec = new StepExecutor(makeEngine(project), makeDeps(handler, {}, undefined));
-    const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
+      const exec = new StepExecutor(makeEngine(project), makeDeps(handler, {}, undefined));
+      const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
 
-    // Order identical to declaration and strictly serial.
-    expect(results.map(r => r.step)).toEqual(['L1', 'L2', 'L3']);
-    expect(live.max).toBe(1); // never concurrent
-    // Intervals do not overlap.
-    const a = interval(timeline, 'L1');
-    const b = interval(timeline, 'L2');
-    const c = interval(timeline, 'L3');
-    expect(overlaps(a, b)).toBe(false);
-    expect(overlaps(b, c)).toBe(false);
-    expect(project.status).toBe('completed');
+      // Order identical to declaration and strictly serial.
+      expect(results.map(r => r.step)).toEqual(['L1', 'L2', 'L3']);
+      expect(live.max).toBe(1); // never concurrent
+      // Intervals do not overlap.
+      const a = interval(timeline, 'L1');
+      const b = interval(timeline, 'L2');
+      const c = interval(timeline, 'L3');
+      expect(overlaps(a, b)).toBe(false);
+      expect(overlaps(b, c)).toBe(false);
+      expect(project.status).toBe('completed');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('a failure halts the whole legacy run (prior behavior preserved)', async () => {
-    const project = makeProject('legacy-fail', [
-      { id: 'F1' }, { id: 'F2' }, { id: 'F3' },
-    ]);
-    project.steps.forEach(s => { delete (s as any).dependsOn; });
-    project.steps[0].status = 'active';
+    vi.useFakeTimers();
+    try {
+      const project = makeProject('legacy-fail', [
+        { id: 'F1' }, { id: 'F2' }, { id: 'F3' },
+      ]);
+      project.steps.forEach(s => { delete (s as any).dependsOn; });
+      project.steps[0].status = 'active';
 
-    const timeline: TimelineEvent[] = [];
-    const handler = makeHandler({ F1: {}, F2: { fail: true }, F3: {} }, timeline);
+      const timeline: TimelineEvent[] = [];
+      const handler = makeHandler({ F1: {}, F2: { fail: true }, F3: {} }, timeline);
 
-    const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
-    const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
+      const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
+      const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
 
-    expect(results.map(r => r.step)).toEqual(['F1', 'F2']); // stopped at the failure
-    expect(project.steps.find(s => s.id === 'F3')!.status).toBe('pending'); // never activated after the halt
+      expect(results.map(r => r.step)).toEqual(['F1', 'F2']); // stopped at the failure
+      expect(project.steps.find(s => s.id === 'F3')!.status).toBe('pending'); // never activated after the halt
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // ── M1.3 — ALP-1557: gate-blocking ──

--- a/gateway/src/services/step-executor-conductor.test.ts
+++ b/gateway/src/services/step-executor-conductor.test.ts
@@ -458,31 +458,36 @@ describe('conductor loop', () => {
 
   // ── M1.3 — ALP-1557: gate-blocking ──
   it('a gated step opens its review gate and blocks only its own dependent branch; parallel siblings keep completing', async () => {
-    // A gates on completion; B depends on A; C is fully independent.
-    const project = makeProject('gate', [
-      { id: 'A', dependsOn: [], gateEnabled: true },
-      { id: 'B', dependsOn: ['A'] },
-      { id: 'C', dependsOn: [] },
-    ]);
-    const timeline: TimelineEvent[] = [];
-    const handler = makeHandler({ A: {}, B: {}, C: {} }, timeline);
+    vi.useFakeTimers();
+    try {
+      // A gates on completion; B depends on A; C is fully independent.
+      const project = makeProject('gate', [
+        { id: 'A', dependsOn: [], gateEnabled: true },
+        { id: 'B', dependsOn: ['A'] },
+        { id: 'C', dependsOn: [] },
+      ]);
+      const timeline: TimelineEvent[] = [];
+      const handler = makeHandler({ A: {}, B: {}, C: {} }, timeline);
 
-    const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
-    const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
+      const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
+      const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
 
-    const byId = Object.fromEntries(project.steps.map(s => [s.id, s]));
-    expect(byId.A.status).toBe('awaiting_review');
-    expect(byId.A.gate).toEqual({ state: 'open', openedAt: expect.any(String) });
-    // B never became ready — depsSatisfied() requires 'completed'/'skipped',
-    // and 'awaiting_review' is neither. No new scheduling logic needed for this.
-    expect(byId.B.status).toBe('pending');
-    // C is on an independent branch and completes normally.
-    expect(byId.C.status).toBe('completed');
+      const byId = Object.fromEntries(project.steps.map(s => [s.id, s]));
+      expect(byId.A.status).toBe('awaiting_review');
+      expect(byId.A.gate).toEqual({ state: 'open', openedAt: expect.any(String) });
+      // B never became ready — depsSatisfied() requires 'completed'/'skipped',
+      // and 'awaiting_review' is neither. No new scheduling logic needed for this.
+      expect(byId.B.status).toBe('pending');
+      // C is on an independent branch and completes normally.
+      expect(byId.C.status).toBe('completed');
 
-    expect(results.find(r => r.step === 'A')).toMatchObject({ success: true, gated: true });
-    expect(results.find(r => r.step === 'B')).toBeUndefined(); // never dispatched
-    // The project can't be "done" while B is still blocked behind the gate.
-    expect(project.status).not.toBe('completed');
+      expect(results.find(r => r.step === 'A')).toMatchObject({ success: true, gated: true });
+      expect(results.find(r => r.step === 'B')).toBeUndefined(); // never dispatched
+      // The project can't be "done" while B is still blocked behind the gate.
+      expect(project.status).not.toBe('completed');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -551,29 +556,34 @@ describe('legacy projects (no dependsOn) run strictly sequentially', () => {
 
   // ── M1.3 — ALP-1557: gate-blocking ──
   it('halts cleanly at a gate — NOT as a failure — and never activates the next step', async () => {
-    const project = makeProject('legacy-gate', [
-      { id: 'G1' }, { id: 'G2', gateEnabled: true }, { id: 'G3' },
-    ]);
-    project.steps.forEach(s => { delete (s as any).dependsOn; });
-    project.steps[0].status = 'active';
+    vi.useFakeTimers();
+    try {
+      const project = makeProject('legacy-gate', [
+        { id: 'G1' }, { id: 'G2', gateEnabled: true }, { id: 'G3' },
+      ]);
+      project.steps.forEach(s => { delete (s as any).dependsOn; });
+      project.steps[0].status = 'active';
 
-    const timeline: TimelineEvent[] = [];
-    const handler = makeHandler({ G1: {}, G2: {}, G3: {} }, timeline);
+      const timeline: TimelineEvent[] = [];
+      const handler = makeHandler({ G1: {}, G2: {}, G3: {} }, timeline);
 
-    const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
-    const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
+      const exec = new StepExecutor(makeEngine(project), makeDeps(handler));
+      const { results } = await exec.autoExecuteLoop(project.id, { workspaceDir });
 
-    // Halted right after the gate — G3 never ran.
-    expect(results.map(r => r.step)).toEqual(['G1', 'G2']);
-    // A gate is NOT an error: every pushed result is success:true, and G2 is
-    // flagged gated so callers can tell "halted" apart from "failed".
-    expect(results.every(r => r.success)).toBe(true);
-    expect(results.find(r => r.step === 'G2')).toMatchObject({ success: true, gated: true });
+      // Halted right after the gate — G3 never ran.
+      expect(results.map(r => r.step)).toEqual(['G1', 'G2']);
+      // A gate is NOT an error: every pushed result is success:true, and G2 is
+      // flagged gated so callers can tell "halted" apart from "failed".
+      expect(results.every(r => r.success)).toBe(true);
+      expect(results.find(r => r.step === 'G2')).toMatchObject({ success: true, gated: true });
 
-    const byId = Object.fromEntries(project.steps.map(s => [s.id, s]));
-    expect(byId.G1.status).toBe('completed');
-    expect(byId.G2.status).toBe('awaiting_review');
-    expect(byId.G3.status).toBe('pending'); // never activated after the halt
-    expect(project.status).not.toBe('completed');
+      const byId = Object.fromEntries(project.steps.map(s => [s.id, s]));
+      expect(byId.G1.status).toBe('completed');
+      expect(byId.G2.status).toBe('awaiting_review');
+      expect(byId.G3.status).toBe('pending'); // never activated after the halt
+      expect(project.status).not.toBe('completed');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/gateway/src/services/step-executor.ts
+++ b/gateway/src/services/step-executor.ts
@@ -21,6 +21,7 @@ import type { ContextEngine } from './context-engine.js';
 import { generateDocxBuffer } from './docx-export.js';
 import { logger } from './logger.js';
 import { docVersionService } from './doc-versions.js';
+import { resolveStepGate } from './project-templates.js';
 import type {
   Project,
   ProjectStep,
@@ -83,6 +84,14 @@ export interface EnginePort {
    * 'completed' status when nothing remains, like completeStep for the last step.
    */
   completeStepBare(projectId: string, stepId: string, result: string): void;
+  /**
+   * Open a step's review gate (M1.3 — ALP-1557) instead of completing it.
+   * Called in place of completeStep/completeStepBare when resolveStepGate()
+   * (project-templates.ts) says the step gates on completion. Persists
+   * status -> 'awaiting_review' + an open StepGate; does NOT advance/activate
+   * a next step — the pipeline simply waits for a human decision.
+   */
+  openStepGate(projectId: string, stepId: string, result: string): void;
   /** Mark a specific pending step 'active' + enrich its prompt (conductor dispatch). */
   activateStep(projectId: string, stepId: string): ProjectStep | null;
   failStep(projectId: string, stepId: string, error: string): void;
@@ -361,14 +370,14 @@ export class StepExecutor {
    * quality loop, file save, context-engine/auto-narrate/assembly hooks.
    */
   async autoExecuteLoop(projectId: string, opts: ExecuteStepOptions): Promise<{
-    results: Array<{ step: string; success: boolean; wordCount?: number; error?: string }>;
+    results: Array<{ step: string; success: boolean; wordCount?: number; error?: string; gated?: boolean }>;
     project: Project | undefined;
   }> {
     const messageHandler = this.deps.getMessageHandler();
     if (!messageHandler) throw new Error('ProjectEngine: message handler not wired (call setMessageHandler)');
     const services = this.deps.getStepServices();
 
-    const results: Array<{ step: string; success: boolean; wordCount?: number; error?: string }> = [];
+    const results: Array<{ step: string; success: boolean; wordCount?: number; error?: string; gated?: boolean }> = [];
 
     const project0 = this.engine.getProject(projectId);
     const hasDeps = !!project0 && project0.steps.some((s: any) => Array.isArray(s.dependsOn));
@@ -389,7 +398,7 @@ export class StepExecutor {
   private async legacySequentialLoop(
     projectId: string,
     opts: ExecuteStepOptions,
-    results: Array<{ step: string; success: boolean; wordCount?: number; error?: string }>,
+    results: Array<{ step: string; success: boolean; wordCount?: number; error?: string; gated?: boolean }>,
     messageHandler: MessageHandler,
     services: StepServices,
   ): Promise<void> {
@@ -405,7 +414,10 @@ export class StepExecutor {
 
       const outcome = await this.runStep(projectId, activeStep.id, opts, results, messageHandler, services, true);
       // Legacy contract: ANY failure (provider failure, short response, or a
-      // thrown error) halts the entire run.
+      // thrown error) halts the entire run. A gate (M1.3 — ALP-1557) also
+      // halts the loop the same way — `halt` just means "stop looping" — but
+      // it is NOT a failure: runStep pushes a success:true/gated:true result
+      // and never calls failStep(), so this halt is silent, not an error.
       if (outcome.halt) break;
 
       // Re-check pause AFTER step completes (catches /stop sent during long AI call)
@@ -422,6 +434,12 @@ export class StepExecutor {
    *     completed; let in-flight steps finish, then halt.
    *   - Failure: a failed step is left failed → its dependents' deps never
    *     satisfy → only that branch stalls; independent branches keep running.
+   *   - Gate (M1.3 — ALP-1557): a gated step opens its review gate and lands
+   *     in 'awaiting_review' — NOT 'completed'/'skipped' — so depsSatisfied()
+   *     below blocks its dependents exactly like a failure would, with no new
+   *     scheduling logic: this falls straight out of the existing ready-set
+   *     computation. Independent branches (not downstream of the gate) keep
+   *     dispatching normally.
    *   - Termination: loop ends when nothing is ready AND nothing is in flight.
    * Total concurrent AI calls are bounded by CONCURRENCY (each runStep issues
    * its AI calls sequentially), so no retry storm.
@@ -429,7 +447,7 @@ export class StepExecutor {
   private async conductorLoop(
     projectId: string,
     opts: ExecuteStepOptions,
-    results: Array<{ step: string; success: boolean; wordCount?: number; error?: string }>,
+    results: Array<{ step: string; success: boolean; wordCount?: number; error?: string; gated?: boolean }>,
     messageHandler: MessageHandler,
     services: StepServices,
   ): Promise<void> {
@@ -503,20 +521,22 @@ export class StepExecutor {
    * next step) and the conductor (advance=false → completeStepBare; the
    * supervisor owns dispatch).
    *
-   * Returns `{ success, halt }`. `halt` marks a failure that the legacy loop
-   * treats as a hard stop (provider failure / short response / thrown error).
-   * The conductor ignores `halt` — a failed step simply blocks its dependents.
+   * Returns `{ success, halt, gated? }`. `halt` marks either a failure OR a
+   * gate — both stop the legacy loop from advancing — but only a failure
+   * calls failStep()/pushes an error result. The conductor ignores `halt`
+   * either way — a blocked step (failed or gated) simply blocks its
+   * dependents via depsSatisfied(), independent branches keep running.
    * Pushes exactly one entry onto `results`, matching the prior behavior.
    */
   private async runStep(
     projectId: string,
     stepId: string,
     opts: ExecuteStepOptions,
-    results: Array<{ step: string; success: boolean; wordCount?: number; error?: string }>,
+    results: Array<{ step: string; success: boolean; wordCount?: number; error?: string; gated?: boolean }>,
     messageHandler: MessageHandler,
     services: StepServices,
     advance: boolean,
-  ): Promise<{ success: boolean; halt: boolean }> {
+  ): Promise<{ success: boolean; halt: boolean; gated?: boolean }> {
     const { join } = await import('path');
     const { mkdir, writeFile } = await import('fs/promises');
     const workspaceDir = opts.workspaceDir;
@@ -715,6 +735,29 @@ export class StepExecutor {
         await writeFile(canonicalPath, stepContent, 'utf-8');
       } catch (err) {
         logger.debug('step output file save / versioning failed', err);
+      }
+
+      // ── Gate check (M1.3 — ALP-1557) ──────────────────────────────────
+      // A gated step (resolveStepGate() — project-templates.ts) opens its
+      // review gate instead of completing: the version is already written
+      // above, so this only flips status -> 'awaiting_review' and emits a
+      // gate-opened event. Deliberately does NOT call complete() (no
+      // completeStep/completeStepBare) and skips every downstream hook
+      // (context-engine memory, auto-narrate, manuscript assembly) below —
+      // none of that should treat unapproved content as canonical yet.
+      if (resolveStepGate(activeStep, currentProject)) {
+        this.engine.openStepGate(currentProject.id, activeStep.id, response);
+        services.heartbeat?.addWords(wordCount);
+        results.push({ step: activeStep.label, success: true, wordCount, gated: true });
+        services.activityLog?.log({
+          type: 'gate_opened',
+          source: 'internal',
+          goalId: currentProject.id,
+          stepLabel: activeStep.label,
+          message: `🔒 "${activeStep.label}" is ready for your review — awaiting approval before the pipeline continues.`,
+          metadata: { wordCount },
+        });
+        return { success: true, halt: true, gated: true };
       }
 
       complete(response);

--- a/gateway/src/services/step-executor.ts
+++ b/gateway/src/services/step-executor.ts
@@ -20,6 +20,7 @@
 import type { ContextEngine } from './context-engine.js';
 import { generateDocxBuffer } from './docx-export.js';
 import { logger } from './logger.js';
+import { docVersionService } from './doc-versions.js';
 import type {
   Project,
   ProjectStep,
@@ -699,14 +700,21 @@ export class StepExecutor {
 
       const wordCount = response.split(/\s+/).length;
 
-      // Save to file
+      // Save to file + append immutable version
       try {
         const projectDir = join(workspaceDir, 'projects', currentProject.title.toLowerCase().replace(/[^a-z0-9]+/g, '-'));
         await mkdir(projectDir, { recursive: true });
         const stepFileName = `${activeStep.id}-${activeStep.label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}.md`;
-        await writeFile(join(projectDir, stepFileName), `# ${activeStep.label}\n\n${response}`, 'utf-8');
+        const canonicalPath = join(projectDir, stepFileName);
+        const stepContent = `# ${activeStep.label}\n\n${response}`;
+
+        // Append to immutable version storage
+        await docVersionService.appendVersion(projectDir, activeStep.id, stepContent);
+
+        // Write canonical/current pointer
+        await writeFile(canonicalPath, stepContent, 'utf-8');
       } catch (err) {
-        logger.debug('step output file save failed', err);
+        logger.debug('step output file save / versioning failed', err);
       }
 
       complete(response);

--- a/gateway/src/services/step-executor.ts
+++ b/gateway/src/services/step-executor.ts
@@ -774,6 +774,12 @@ export class StepExecutor {
         }
       });
 
+      // SEAM (ALP-1595 follow-on): book-bible.md is currently compiled
+      // on-demand only (POST /api/projects/:id/book-bible). Auto-regenerate
+      // was left out of v1 scope — when it's built, the natural place to
+      // trigger it is right here, gated on `isBibleStep` above, since that's
+      // already the signal that this step's output feeds the bible.
+
       // ── Auto-narrate completed chapter (opt-in via project.context.autoNarrate) ──
       // Inspired by OpenClaw's chat-scoped /tts auto controls. Generates an audio
       // preview of the just-completed chapter so the author can listen back without

--- a/gateway/src/services/step-executor.ts
+++ b/gateway/src/services/step-executor.ts
@@ -324,6 +324,90 @@ export class StepExecutor {
   }
 
   /**
+   * Rerun an `awaiting_review` step with reviewer feedback folded into its
+   * prompt (M1.5 — ALP-1559, POST .../revise). Unlike executeStepWithRetry
+   * (the plain single-step path, which never touches versioning/gates), this
+   * appends the new response as an immutable version and reopens the gate via
+   * openStepGate/applyStepCompletion — mirroring the file-save + gate-check
+   * runStep already does for the autonomous loop, just for one on-demand step
+   * instead of the whole conductor sweep.
+   */
+  async reviseStep(
+    projectId: string,
+    stepId: string,
+    feedback: string,
+    workspaceDir: string,
+  ): Promise<
+    | { ok: true; response: string; version: number; project: Project }
+    | { ok: false; kind: 'no-project' }
+    | { ok: false; kind: 'no-step' }
+    | { ok: false; kind: 'not-awaiting-review' }
+    | { ok: false; kind: 'provider-failure'; detail: string; project: Project }
+    | { ok: false; kind: 'short-response'; reason: string; project: Project }
+    | { ok: false; kind: 'error'; error: string; project: Project }
+  > {
+    const messageHandler = this.deps.getMessageHandler();
+    if (!messageHandler) throw new Error('ProjectEngine: message handler not wired (call setMessageHandler)');
+    const project = this.engine.getProject(projectId);
+    if (!project) return { ok: false, kind: 'no-project' };
+
+    const step = project.steps.find((s: any) => s.id === stepId);
+    if (!step) return { ok: false, kind: 'no-step' };
+    if (step.status !== 'awaiting_review') return { ok: false, kind: 'not-awaiting-review' };
+
+    step.prompt = `${step.prompt}\n\n## Reviewer feedback (revision requested)\n\n${feedback}`;
+
+    try {
+      const projectContext = await this.engine.buildProjectContext(project, step);
+      const userMessage = await this.buildStepUserMessage(project, step);
+      let response = '';
+
+      await messageHandler(
+        userMessage,
+        'projects',
+        (text: string) => { response = text; },
+        projectContext,
+        step.taskType || undefined,
+      );
+
+      if (!response || response.length < 50) {
+        response = '';
+        await messageHandler(userMessage, 'projects', (text: string) => { response = text; }, projectContext, 'general');
+      }
+
+      if (response && response.startsWith('[AI provider failure]')) {
+        const detail = response.replace(/^\[AI provider failure\]\s*/, '').substring(0, 500);
+        this.engine.failStep(project.id, step.id, detail);
+        return { ok: false, kind: 'provider-failure', detail, project: this.engine.getProject(project.id)! };
+      }
+      if (!response || response.length < 50) {
+        const reason = `AI returned an unusably short response (${response?.length ?? 0} chars) while revising this step.`;
+        this.engine.failStep(project.id, step.id, reason);
+        return { ok: false, kind: 'short-response', reason, project: this.engine.getProject(project.id)! };
+      }
+
+      const { join } = await import('path');
+      const { mkdir, writeFile } = await import('fs/promises');
+      const projectDir = join(workspaceDir, 'projects', project.title.toLowerCase().replace(/[^a-z0-9]+/g, '-'));
+      await mkdir(projectDir, { recursive: true });
+      const stepFileName = `${step.id}-${step.label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}.md`;
+      const stepContent = `# ${step.label}\n\n${response}`;
+      const version = await docVersionService.appendVersion(projectDir, step.id, stepContent, 'agent-patch', 'Revised from reviewer feedback');
+      await writeFile(join(projectDir, stepFileName), stepContent, 'utf-8');
+
+      // openStepGate re-runs applyStepCompletion — since the step's phase is
+      // still gated, this puts it right back into awaiting_review with a fresh
+      // StepGate, exactly like the first time this step completed.
+      this.engine.openStepGate(project.id, step.id, response);
+
+      return { ok: true, response, version, project: this.engine.getProject(project.id)! };
+    } catch (error) {
+      this.engine.failStep(project.id, step.id, String(error));
+      return { ok: false, kind: 'error', error: String(error), project: this.engine.getProject(project.id)! };
+    }
+  }
+
+  /**
    * Serializes context-engine summary/entity extraction so the chapter-continuity
    * memory hooks NEVER run concurrently — even when steps finish out of order.
    * Chapter WRITE steps complete in chapter order (they depend on the prior

--- a/gateway/src/services/workspace-routing.test.ts
+++ b/gateway/src/services/workspace-routing.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, writeFile, readFile, rm } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  resolveWorkspaceRoot,
+  resolveActiveWorkspace,
+  looksLikeLegacyFlatWorkspace,
+  readActiveBookPointer,
+  writeActiveBookPointer,
+  listBooks,
+  scaffoldBookWorkspace,
+  migrateLegacyWorkspace,
+  isValidBookSlug,
+  slugifyBookName,
+} from './workspace-routing.js';
+
+describe('workspace-routing', () => {
+  let root: string;
+  let installRootDir: string;
+
+  beforeEach(async () => {
+    root = join(tmpdir(), `wsr-test-root-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    installRootDir = join(tmpdir(), `wsr-test-install-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(root, { recursive: true });
+    // Minimal bundled skeleton scaffoldBookWorkspace seeds from.
+    await mkdir(join(installRootDir, 'workspace', 'soul'), { recursive: true });
+    await writeFile(join(installRootDir, 'workspace', 'soul', 'SOUL.md'), '# Soul\n');
+    await mkdir(join(installRootDir, 'workspace', 'projects', '.template'), { recursive: true });
+    await writeFile(join(installRootDir, 'workspace', 'projects', '.template', 'README.md'), 'template\n');
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    await rm(installRootDir, { recursive: true, force: true });
+  });
+
+  describe('resolveWorkspaceRoot', () => {
+    it('defaults to the given default root when no env override is set', () => {
+      expect(resolveWorkspaceRoot({}, root)).toBe(root);
+    });
+
+    it('honors AUTHORCLAW_WORKSPACE_DIR', () => {
+      const override = join(tmpdir(), 'override-a');
+      expect(resolveWorkspaceRoot({ AUTHORCLAW_WORKSPACE_DIR: override }, root)).toBe(join(override));
+    });
+
+    it('falls back to the AUTHORCLAW_PROJECTS_ROOT alias', () => {
+      const override = join(tmpdir(), 'override-b');
+      expect(resolveWorkspaceRoot({ AUTHORCLAW_PROJECTS_ROOT: override }, root)).toBe(join(override));
+    });
+
+    it('prefers AUTHORCLAW_WORKSPACE_DIR over the alias when both are set', () => {
+      const primary = join(tmpdir(), 'override-primary');
+      const alias = join(tmpdir(), 'override-alias');
+      expect(
+        resolveWorkspaceRoot({ AUTHORCLAW_WORKSPACE_DIR: primary, AUTHORCLAW_PROJECTS_ROOT: alias }, root),
+      ).toBe(join(primary));
+    });
+  });
+
+  describe('legacy flat workspace (default/legacy resolution)', () => {
+    it('is not detected as legacy when the root is empty', () => {
+      expect(looksLikeLegacyFlatWorkspace(root)).toBe(false);
+    });
+
+    it('is detected as legacy when memory/, soul/, or projects/ sit directly under the root', async () => {
+      await mkdir(join(root, 'soul'), { recursive: true });
+      expect(looksLikeLegacyFlatWorkspace(root)).toBe(true);
+    });
+
+    it('resolves WORKSPACE_DIR to the root itself for a legacy install with no active book set', async () => {
+      await mkdir(join(root, 'memory'), { recursive: true });
+      await mkdir(join(root, 'soul'), { recursive: true });
+      await mkdir(join(root, 'projects'), { recursive: true });
+
+      const resolved = resolveActiveWorkspace(root, {});
+
+      expect(resolved.mode).toBe('legacy-flat');
+      expect(resolved.workspaceDir).toBe(root);
+      expect(resolved.activeBook).toBeNull();
+    });
+
+    it('defaults an empty, non-legacy root to a "default" book subdirectory', () => {
+      const resolved = resolveActiveWorkspace(root, {});
+
+      expect(resolved.mode).toBe('default-book');
+      expect(resolved.activeBook).toBe('default');
+      expect(resolved.workspaceDir).toBe(join(root, 'default'));
+    });
+  });
+
+  describe('active-book resolution (env + pointer)', () => {
+    it('AUTHORCLAW_ACTIVE_BOOK env resolves to that book, even over a legacy-looking root', async () => {
+      await mkdir(join(root, 'soul'), { recursive: true });
+
+      const resolved = resolveActiveWorkspace(root, { AUTHORCLAW_ACTIVE_BOOK: 'book-two' });
+
+      expect(resolved.mode).toBe('active-book');
+      expect(resolved.activeBook).toBe('book-two');
+      expect(resolved.workspaceDir).toBe(join(root, 'book-two'));
+    });
+
+    it('falls back to the .active-book pointer file when no env var is set', async () => {
+      await writeActiveBookPointer(root, 'pointed-book');
+
+      const resolved = resolveActiveWorkspace(root, {});
+
+      expect(resolved.mode).toBe('active-book');
+      expect(resolved.activeBook).toBe('pointed-book');
+      expect(resolved.workspaceDir).toBe(join(root, 'pointed-book'));
+    });
+
+    it('env wins over the pointer file when both are set', async () => {
+      await writeActiveBookPointer(root, 'pointer-book');
+
+      const resolved = resolveActiveWorkspace(root, { AUTHORCLAW_ACTIVE_BOOK: 'env-book' });
+
+      expect(resolved.activeBook).toBe('env-book');
+    });
+
+    it('readActiveBookPointer trims whitespace and returns null when no pointer file exists', async () => {
+      expect(readActiveBookPointer(root)).toBeNull();
+      await mkdir(root, { recursive: true });
+      await writeFile(join(root, '.active-book'), '  spaced-book  \n');
+      expect(readActiveBookPointer(root)).toBe('spaced-book');
+    });
+  });
+
+  describe('slug validation', () => {
+    it('accepts lowercase alphanumeric-hyphen slugs', () => {
+      expect(isValidBookSlug('the-algorithm-of-wanting')).toBe(true);
+      expect(isValidBookSlug('book2')).toBe(true);
+    });
+
+    it('rejects reserved names', () => {
+      expect(isValidBookSlug('memory')).toBe(false);
+      expect(isValidBookSlug('soul')).toBe(false);
+      expect(isValidBookSlug('.active-book')).toBe(false);
+    });
+
+    it('slugifyBookName produces filesystem-safe, non-empty slugs', () => {
+      expect(slugifyBookName('My Second Book!')).toBe('my-second-book');
+      expect(slugifyBookName('')).toBe('untitled');
+    });
+  });
+
+  describe('scaffoldBookWorkspace (new-book scaffolding)', () => {
+    it('creates an isolated directory skeleton and seeds bundled default files', async () => {
+      const bookDir = await scaffoldBookWorkspace(root, 'new-book', installRootDir);
+
+      expect(bookDir).toBe(join(root, 'new-book'));
+      for (const dir of ['memory/conversations', 'soul', 'projects', 'images', 'audio', '.audit']) {
+        expect(existsSync(join(bookDir, dir))).toBe(true);
+      }
+      expect(existsSync(join(bookDir, 'soul', 'SOUL.md'))).toBe(true);
+      expect(await readFile(join(bookDir, 'soul', 'SOUL.md'), 'utf-8')).toBe('# Soul\n');
+      expect(existsSync(join(bookDir, 'projects', '.template', 'README.md'))).toBe(true);
+    });
+
+    it('rejects invalid slugs', async () => {
+      await expect(scaffoldBookWorkspace(root, 'memory', installRootDir)).rejects.toThrow();
+      await expect(scaffoldBookWorkspace(root, 'Not Valid', installRootDir)).rejects.toThrow();
+    });
+
+    it('refuses to overwrite an existing book workspace', async () => {
+      await scaffoldBookWorkspace(root, 'dup-book', installRootDir);
+      await expect(scaffoldBookWorkspace(root, 'dup-book', installRootDir)).rejects.toThrow(/already exists/);
+    });
+
+    it('two scaffolded books are fully isolated from each other', async () => {
+      const bookA = await scaffoldBookWorkspace(root, 'book-a', installRootDir);
+      const bookB = await scaffoldBookWorkspace(root, 'book-b', installRootDir);
+
+      await writeFile(join(bookA, 'memory', 'note.md'), 'only in book a');
+
+      expect(existsSync(join(bookB, 'memory', 'note.md'))).toBe(false);
+    });
+  });
+
+  describe('migrateLegacyWorkspace', () => {
+    it('moves legacy top-level entries into <root>/<slug>/ and sets the active-book pointer, losing nothing', async () => {
+      await mkdir(join(root, 'memory'), { recursive: true });
+      await mkdir(join(root, 'soul'), { recursive: true });
+      await mkdir(join(root, 'projects', 'the-book'), { recursive: true });
+      await writeFile(join(root, 'soul', 'SOUL.md'), 'existing soul content');
+      await writeFile(join(root, 'costs.json'), '{}');
+
+      const bookDir = await migrateLegacyWorkspace(root, 'my-book');
+
+      expect(bookDir).toBe(join(root, 'my-book'));
+      expect(await readFile(join(bookDir, 'soul', 'SOUL.md'), 'utf-8')).toBe('existing soul content');
+      expect(existsSync(join(bookDir, 'projects', 'the-book'))).toBe(true);
+      expect(existsSync(join(bookDir, 'costs.json'))).toBe(true);
+      expect(readActiveBookPointer(root)).toBe('my-book');
+
+      // Resolution now routes to the migrated book, not the (emptied) root.
+      const resolved = resolveActiveWorkspace(root, {});
+      expect(resolved.workspaceDir).toBe(bookDir);
+    });
+
+    it('refuses to migrate a root that does not look legacy', async () => {
+      await expect(migrateLegacyWorkspace(root, 'my-book')).rejects.toThrow(/does not look like/);
+    });
+
+    it('refuses to overwrite an existing migration target', async () => {
+      await mkdir(join(root, 'memory'), { recursive: true });
+      await mkdir(join(root, 'my-book'), { recursive: true });
+
+      await expect(migrateLegacyWorkspace(root, 'my-book')).rejects.toThrow(/already exists/);
+    });
+  });
+
+  describe('listBooks', () => {
+    it('returns an empty list for a nonexistent root', async () => {
+      expect(await listBooks(join(root, 'does-not-exist'))).toEqual([]);
+    });
+
+    it('lists book directories and marks the active one', async () => {
+      await scaffoldBookWorkspace(root, 'book-a', installRootDir);
+      await scaffoldBookWorkspace(root, 'book-b', installRootDir);
+      await writeActiveBookPointer(root, 'book-b');
+
+      const books = await listBooks(root);
+
+      expect(books).toEqual([
+        { slug: 'book-a', active: false },
+        { slug: 'book-b', active: true },
+      ]);
+    });
+  });
+});

--- a/gateway/src/services/workspace-routing.test.ts
+++ b/gateway/src/services/workspace-routing.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdir, writeFile, readFile, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
@@ -21,8 +21,10 @@ describe('workspace-routing', () => {
   let installRootDir: string;
 
   beforeEach(async () => {
-    root = join(tmpdir(), `wsr-test-root-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-    installRootDir = join(tmpdir(), `wsr-test-install-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    // Use a counter to ensure unique test dirs, avoiding race conditions under concurrent test runs
+    const counter = Math.floor(Math.random() * 1_000_000_000);
+    root = join(tmpdir(), `wsr-test-root-${counter}`);
+    installRootDir = join(tmpdir(), `wsr-test-install-${counter}`);
     await mkdir(root, { recursive: true });
     // Minimal bundled skeleton scaffoldBookWorkspace seeds from.
     await mkdir(join(installRootDir, 'workspace', 'soul'), { recursive: true });

--- a/gateway/src/services/workspace-routing.test.ts
+++ b/gateway/src/services/workspace-routing.test.ts
@@ -230,6 +230,6 @@ describe('workspace-routing', () => {
         { slug: 'book-a', active: false },
         { slug: 'book-b', active: true },
       ]);
-    });
+    }, 30000);
   });
 });

--- a/gateway/src/services/workspace-routing.ts
+++ b/gateway/src/services/workspace-routing.ts
@@ -1,0 +1,232 @@
+/**
+ * Per-book workspace routing (ALP-1596 / ALP-1547).
+ *
+ * Historically `AUTHORCLAW_WORKSPACE_DIR` pointed straight at ONE flat
+ * directory holding every book's state (memory, soul, projects, costs,
+ * images, ...), resolved once at boot into ~35 singleton services. One
+ * running instance == one book, permanently.
+ *
+ * This module treats that same env var as a ROOT that can hold MANY
+ * per-book workspaces at `<root>/<book-slug>/`, plus an "active book"
+ * selector that decides which one boots. Switching is restart-scoped —
+ * services are boot-time singletons, so there is no hot-swap.
+ *
+ * Backward compatibility is load-bearing: an existing flat install (has
+ * `memory/`, `soul/`, or `projects/` directly under the root, no active book
+ * selected) is detected as LEGACY and the root itself is used as the
+ * workspace dir, unchanged from pre-ALP-1596 behavior. No migration is
+ * required to keep an existing single-book install running. A book can still
+ * be migrated into the multi-book layout on purpose via `migrateLegacyBook`.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { mkdir, readdir, rename, cp } from 'fs/promises';
+import { join, resolve } from 'path';
+
+/** Directory/file names that already mean something at the workspace root — never valid book slugs. */
+export const RESERVED_BOOK_SLUGS = new Set([
+  'memory',
+  'soul',
+  'projects',
+  'images',
+  'audio',
+  'character-voices',
+  'plot-promises',
+  'context',
+  'documents',
+  'data',
+  'exports',
+  'research',
+  'config',
+  'dashboard',
+  '.audit',
+  '.agent',
+  '.config',
+  '.active-book',
+]);
+
+/** Subset of the reserved names that, if present directly under the root, signal a legacy flat workspace. */
+const LEGACY_SIGNAL_DIRS = ['memory', 'soul', 'projects'];
+
+/** The empty directory skeleton a book workspace needs (mirrors scripts/setup-wizard.sh). */
+const BOOK_SKELETON_DIRS = [
+  'memory/conversations',
+  'memory/book-bible',
+  'memory/voice-data',
+  'projects',
+  'exports',
+  'research',
+  '.audit',
+  'soul',
+  'images',
+  'audio',
+  'character-voices',
+  'plot-promises',
+  'context',
+  'documents',
+  'data',
+];
+
+/** Known seed files/dirs copied from the install's bundled default skeleton when scaffolding a new book. */
+const SEED_PATHS = [
+  'soul/SOUL.md',
+  'soul/PERSONALITY.md',
+  'soul/STYLE-GUIDE.md',
+  'soul/VOICE-PROFILE.template.md',
+  'projects/.template',
+];
+
+const ACTIVE_BOOK_POINTER_FILE = '.active-book';
+
+export type WorkspaceMode = 'legacy-flat' | 'active-book' | 'default-book';
+
+export interface ResolvedWorkspace {
+  /** The multi-book root (== AUTHORCLAW_WORKSPACE_DIR / AUTHORCLAW_PROJECTS_ROOT, resolved). */
+  root: string;
+  /** The directory actually passed to services as WORKSPACE_DIR. */
+  workspaceDir: string;
+  /** null in legacy-flat mode — there is no book slug, the root IS the book. */
+  activeBook: string | null;
+  mode: WorkspaceMode;
+}
+
+export function isValidBookSlug(slug: string): boolean {
+  return /^[a-z0-9][a-z0-9-]*$/.test(slug) && !RESERVED_BOOK_SLUGS.has(slug);
+}
+
+/** Filesystem-safe slug of a book name. Never returns empty. */
+export function slugifyBookName(text: string): string {
+  return (
+    String(text || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'untitled'
+  );
+}
+
+/** The multi-book root: AUTHORCLAW_WORKSPACE_DIR, falling back to the AUTHORCLAW_PROJECTS_ROOT alias, then the default. */
+export function resolveWorkspaceRoot(env: NodeJS.ProcessEnv, defaultRoot: string): string {
+  const override = env.AUTHORCLAW_WORKSPACE_DIR || env.AUTHORCLAW_PROJECTS_ROOT;
+  return override ? resolve(override) : defaultRoot;
+}
+
+/** A flat single-book install: memory/, soul/, or projects/ sit directly under the root. */
+export function looksLikeLegacyFlatWorkspace(root: string): boolean {
+  return LEGACY_SIGNAL_DIRS.some((dir) => existsSync(join(root, dir)));
+}
+
+// Synchronous by design: resolveActiveWorkspace runs at gateway boot, before
+// the async initialize() phase, so index.ts can keep computing WORKSPACE_DIR
+// as a plain top-level const rather than introducing top-level await into a
+// 2,600-line entry file for one small resolution step.
+export function readActiveBookPointer(root: string): string | null {
+  const pointerPath = join(root, ACTIVE_BOOK_POINTER_FILE);
+  if (!existsSync(pointerPath)) return null;
+  const raw = readFileSync(pointerPath, 'utf-8').trim();
+  return raw || null;
+}
+
+export function writeActiveBookPointer(root: string, slug: string): void {
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, ACTIVE_BOOK_POINTER_FILE), `${slug}\n`, 'utf-8');
+}
+
+/**
+ * Resolve which directory should be used as WORKSPACE_DIR for this boot.
+ * Precedence for the active book: AUTHORCLAW_ACTIVE_BOOK env > `.active-book`
+ * pointer file > legacy-flat detection > 'default' (fresh multi-book root).
+ */
+export function resolveActiveWorkspace(root: string, env: NodeJS.ProcessEnv): ResolvedWorkspace {
+  const envActiveBook = env.AUTHORCLAW_ACTIVE_BOOK?.trim() || null;
+  const activeBook = envActiveBook || readActiveBookPointer(root);
+
+  if (!activeBook) {
+    if (looksLikeLegacyFlatWorkspace(root)) {
+      return { root, workspaceDir: root, activeBook: null, mode: 'legacy-flat' };
+    }
+    return { root, workspaceDir: join(root, 'default'), activeBook: 'default', mode: 'default-book' };
+  }
+
+  return { root, workspaceDir: join(root, activeBook), activeBook, mode: 'active-book' };
+}
+
+export interface BookInfo {
+  slug: string;
+  active: boolean;
+}
+
+/** List per-book workspace directories under root, marking the currently active one (if any). */
+export async function listBooks(root: string): Promise<BookInfo[]> {
+  if (!existsSync(root)) return [];
+  const entries = await readdir(root, { withFileTypes: true });
+  const active = readActiveBookPointer(root);
+  return entries
+    .filter((e) => e.isDirectory() && !RESERVED_BOOK_SLUGS.has(e.name) && !e.name.startsWith('.'))
+    .map((e) => ({ slug: e.name, active: e.name === active }))
+    .sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+/**
+ * Scaffold a new, isolated book workspace at `<root>/<slug>/`: the empty
+ * directory skeleton plus the install's bundled default seed files (soul
+ * docs, project template) copied from `<installRootDir>/workspace`.
+ */
+export async function scaffoldBookWorkspace(root: string, slug: string, installRootDir: string): Promise<string> {
+  if (!isValidBookSlug(slug)) {
+    throw new Error(
+      `"${slug}" is not a valid book slug (lowercase letters/digits/hyphens, and not a reserved name like ${[...RESERVED_BOOK_SLUGS].slice(0, 3).join(', ')}, ...).`,
+    );
+  }
+  const bookDir = join(root, slug);
+  if (existsSync(bookDir)) {
+    throw new Error(`Book workspace already exists: ${bookDir}`);
+  }
+
+  for (const dir of BOOK_SKELETON_DIRS) {
+    await mkdir(join(bookDir, dir), { recursive: true });
+  }
+
+  const seedRoot = join(installRootDir, 'workspace');
+  for (const seedPath of SEED_PATHS) {
+    const src = join(seedRoot, seedPath);
+    if (!existsSync(src)) continue;
+    await cp(src, join(bookDir, seedPath), { recursive: true });
+  }
+
+  return bookDir;
+}
+
+/**
+ * One-command migration for an existing flat/legacy install: move the known
+ * legacy top-level entries into `<root>/<slug>/` and point `.active-book` at
+ * it. No data is deleted — everything recognized is moved, nothing else is
+ * touched. Idempotent-ish: refuses to run if `<root>/<slug>/` already exists,
+ * so it can't be accidentally run twice and clobber a real book.
+ */
+export async function migrateLegacyWorkspace(root: string, slug: string): Promise<string> {
+  if (!isValidBookSlug(slug)) {
+    throw new Error(`"${slug}" is not a valid book slug.`);
+  }
+  if (!looksLikeLegacyFlatWorkspace(root)) {
+    throw new Error(`${root} does not look like a legacy flat workspace (no memory/, soul/, or projects/ directly under it).`);
+  }
+  const bookDir = join(root, slug);
+  if (existsSync(bookDir)) {
+    throw new Error(`Migration target already exists: ${bookDir}. Refusing to overwrite — pick a different slug.`);
+  }
+
+  const entries = await readdir(root, { withFileTypes: true });
+  await mkdir(bookDir, { recursive: true });
+
+  for (const entry of entries) {
+    if (entry.name === ACTIVE_BOOK_POINTER_FILE) continue;
+    // A book slug directory that already exists at the root (e.g. from a
+    // prior partial migration under a different slug) is left alone rather
+    // than swept into this migration — only known-legacy entries move.
+    if (entry.isDirectory() && !RESERVED_BOOK_SLUGS.has(entry.name) && !LEGACY_SIGNAL_DIRS.includes(entry.name)) continue;
+    await rename(join(root, entry.name), join(bookDir, entry.name));
+  }
+
+  writeActiveBookPointer(root, slug);
+  return bookDir;
+}

--- a/gateway/src/skills/loader.test.ts
+++ b/gateway/src/skills/loader.test.ts
@@ -261,18 +261,18 @@ describe('SkillLoader.matchSkills — ranking, cap, budget', () => {
     expect(results[0]).toContain('multi-hit');
   });
 
-  it('caps results at MAX_MATCHED_SKILLS (3) even when more skills match', async () => {
-    for (let i = 0; i < 5; i++) {
+  it('caps results at MAX_MATCHED_SKILLS (5) even when more skills match', async () => {
+    for (let i = 0; i < 7; i++) {
       await writeSkillFixture(skillsDir, 'core', `skill-${i}`, {
         description: `Skill ${i}`,
         triggers: [`trigger${i}`],
       });
     }
     await loader.loadAll();
-    const input = 'trigger0 trigger1 trigger2 trigger3 trigger4';
+    const input = 'trigger0 trigger1 trigger2 trigger3 trigger4 trigger5 trigger6';
     const results = loader.matchSkills(input);
-    expect(results.length).toBeLessThanOrEqual(3);
-    expect(results).toHaveLength(3);
+    expect(results.length).toBeLessThanOrEqual(5);
+    expect(results).toHaveLength(5);
   });
 
   it('matching is case-insensitive', async () => {
@@ -306,11 +306,11 @@ describe('SkillLoader.matchSkills — ranking, cap, budget', () => {
     }
   });
 
-  it('truncates a skill body that would exceed the ~8000-char budget and appends [truncated]', async () => {
+  it('truncates a skill body that would exceed the ~15000-char budget and appends [truncated]', async () => {
     await writeSkillFixture(skillsDir, 'core', 'giant-skill', {
       description: 'Giant skill body',
       triggers: ['giant'],
-      body: 'y'.repeat(10000),
+      body: 'y'.repeat(18000),
     });
     await loader.loadAll();
     const results = loader.matchSkills('giant');
@@ -331,18 +331,19 @@ describe('SkillLoader.matchSkills — ranking, cap, budget', () => {
   });
 
   it('omits body entirely (description-only) once the budget is fully exhausted by prior matches', async () => {
-    // Two large skills that both match, ranked so the first consumes the
-    // entire ~8000 char budget, leaving <=200 chars remaining for the second
-    // (triggering the "budget exhausted" branch rather than a truncated slice).
+    // Two large skills that both match, ranked so the first consumes nearly
+    // the entire ~15000 char budget, leaving <=200 chars remaining for the
+    // second (triggering the "budget exhausted" branch rather than a
+    // truncated slice).
     await writeSkillFixture(skillsDir, 'core', 'first-huge', {
       description: 'First huge, matches twice for higher score',
       triggers: ['sharedterm', 'firsthuge'],
-      body: 'z'.repeat(7950),
+      body: 'z'.repeat(14900),
     });
     await writeSkillFixture(skillsDir, 'core', 'second-huge', {
       description: 'Second huge',
       triggers: ['sharedterm'],
-      body: 'w'.repeat(7950),
+      body: 'w'.repeat(14900),
     });
     await loader.loadAll();
     const results = loader.matchSkills('sharedterm firsthuge appears in this input');

--- a/gateway/src/skills/loader.ts
+++ b/gateway/src/skills/loader.ts
@@ -227,7 +227,10 @@ export class SkillLoader {
 
   private parseSkill(content: string, name: string, category: 'core' | 'author' | 'marketing' | 'premium' | 'ops'): Skill | null {
     // Parse YAML frontmatter
-    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    // Note: tolerate CRLF line endings (\r\n) — a checkout with git's Windows
+    // default `core.autocrlf=true` produces \r\n-terminated SKILL.md files,
+    // and a bare \n-only regex here silently fails to match every skill.
+    const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     if (!frontmatterMatch) {
       if (!this.warnedSkills.has(name)) {
         this.warnedSkills.add(name);

--- a/gateway/src/skills/loader.ts
+++ b/gateway/src/skills/loader.ts
@@ -287,8 +287,16 @@ export class SkillLoader {
    * callers join these into the system prompt).
    */
   matchSkills(input: string): string[] {
-    const MAX_MATCHED_SKILLS = 3;
-    const CONTENT_BUDGET_CHARS = 8000;
+    // Raised from 3/8,000 now that the claude-cli provider carries far less
+    // dead weight per call (~28,800 tokens of Claude Code's own agentic
+    // scaffolding removed — see router.ts's buildClaudeCliArgs) and
+    // MemoryService.getRelevant() is bounded (was unbounded up to 50,000
+    // chars, now capped at 8,000). This budget is what actually reaches the
+    // model as craft guidance — the loader was previously logging
+    // "body truncated" / "body omitted — prompt budget exhausted" under the
+    // old cap, meaning skill content was losing to prompt bloat.
+    const MAX_MATCHED_SKILLS = 5;
+    const CONTENT_BUDGET_CHARS = 15000;
 
     const lower = input.toLowerCase();
     const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "authorclaw",
+  "name": "authoragent",
   "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "authorclaw",
+      "name": "authoragent",
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
@@ -34,13 +34,39 @@
         "node": ">=22.0.0"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -720,6 +746,40 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
@@ -926,6 +986,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -1053,9 +1122,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -1191,9 +1260,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -1204,7 +1273,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -1586,20 +1655,21 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.5.tgz",
-      "integrity": "sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==",
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",
         "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
         "cookie": "~0.7.2",
         "cors": "~2.8.5",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3"
+        "ws": "~8.21.0"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -1663,9 +1733,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1769,14 +1839,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -1795,7 +1865,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -2002,9 +2072,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2553,9 +2623,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.0.tgz",
-      "integrity": "sha512-TBm6j41rxNohqawsxlsWsNNh/VdV4QFXcBvRcPhXaA05EZ79z0qJ2bQFpync6JBoHTeNY5Q1JpG7AlTjdlfAEA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -2702,9 +2772,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -2727,7 +2797,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2736,9 +2805,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2756,7 +2825,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2765,9 +2834,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2840,12 +2909,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -3071,14 +3141,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -3090,13 +3160,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3213,13 +3283,13 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
-      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
       "license": "MIT",
       "dependencies": {
         "debug": "~4.4.1",
-        "ws": "~8.18.3"
+        "ws": "~8.21.0"
       }
     },
     "node_modules/socket.io-adapter/node_modules/debug": {
@@ -3246,9 +3316,9 @@
       "license": "MIT"
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
-      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -3503,7 +3573,6 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3608,7 +3677,6 @@
       "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3812,9 +3880,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node --import tsx gateway/src/index.ts",
     "dev": "node --watch --import tsx gateway/src/index.ts",
+    "book": "node --import tsx gateway/src/cli/book.ts",
     "build": "tsc",
     "setup": "bash scripts/setup-wizard.sh",
     "setup:legacy": "bash scripts/setup.sh",

--- a/package.json
+++ b/package.json
@@ -64,5 +64,9 @@
   },
   "engines": {
     "node": ">=22.0.0"
+  },
+  "allowScripts": {
+    "better-sqlite3@11.10.0": true,
+    "esbuild@0.27.3": true
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
     // are `.ts` — this is standard NodeNext/tsx convention and vitest/esbuild
     // resolve it correctly without extra config.
     restoreMocks: true,
+    testTimeout: 15000,
   },
 });

--- a/workspace/SKILLS.txt
+++ b/workspace/SKILLS.txt
@@ -1,26 +1,128 @@
 AUTHORAGENT SKILLS REFERENCE
-Auto-generated on startup — 5 skills loaded
+Auto-generated on startup — 29 skills loaded
 ════════════════════════════════════════════════════════════
 
-── Author Skills (5) ──
+── Core Skills (6) ──
 
-  author-os-workflow
-    Run an Author OS Workflow Engine template — JSON-defined writing workflows from Author OS
-    Keywords: run workflow, workflow template, author os workflow, load template, workflow engine, novel writing templates, quick actions templates, quick start, readme, revision templates
+  after-action-review
+    Structured post-goal reflection that extracts lessons, evaluates quality, and feeds the self-improvement loop
+    Keywords: after action review, review goal, post mortem, what went well, what went wrong, retrospective, goal review, debrief
 
-  author-os-book-bible
-    Use the Author OS Book Bible Engine for character / world / timeline tracking
-    Keywords: book bible, world bible, character bible, author os bible, series bible, readme, userguide
+  error-recovery
+    Intelligent error diagnosis, automatic recovery strategies, and prevention of recurring failures
+    Keywords: error, fix error, something broke, failed, not working, debug, troubleshoot, diagnose, recovery
 
-  author-os-autopsy
-    Run Author OS Manuscript Autopsy — pacing + structure + craft analysis on a manuscript
-    Keywords: manuscript autopsy, autopsy, analyze my manuscript, pacing analysis, structure analysis, readme
+  preference-learner
+    Track and learn user preferences for writing style, communication, and workflow
+    Keywords: my preferences, remember that I, I prefer, I like, I don't like, I always want, I never want, update preferences, show preferences, preference
 
-  author-os-library
-    Browse the Author OS AI Author Library for prompts, voice markers, and writing references
-    Keywords: author library, writing prompts, voice markers, prompt library, ai author library
+  prompt-optimizer
+    Automatically improves prompts based on output quality, user feedback, and A/B testing results
+    Keywords: optimize prompt, improve prompt, better prompt, prompt quality, test prompts, prompt a/b test, prompt lab
 
-  author-os-marketing
-    Generate marketing assets via the Author OS Creator Asset Suite — blurbs, ads, social posts
-    Keywords: creator asset, marketing assets, asset suite, author os marketing, launch assets
+  self-improve
+    Continuous self-improvement loop — AuthorAgent learns from mistakes, successes, and user feedback to get better over time
+    Keywords: self improve, improve yourself, learn from, what did you learn, improvement log, get better, lessons learned, self reflection, review performance
+
+  skill-acquisition
+    Research topics and create new skills for AuthorAgent to learn
+    Keywords: learn how to, add a skill for, find a tool for, go learn, research and create a skill, teach yourself, acquire skill, learn about
+
+── Author Skills (15) ──
+
+  beta-reader
+    Simulate beta reader feedback from different reader perspectives
+    Keywords: beta read, beta reader, reader feedback, test reader, would readers
+
+  book-bible
+    Maintain world consistency - characters, timeline, locations, rules, items
+    Keywords: book bible, character, character sheet, timeline, world building, world bible, consistency, continuity
+
+  continuity-check
+    Scan manuscript for inconsistencies in characters, timeline, settings, and names
+    Keywords: continuity, continuity check, consistency check, find inconsistencies, timeline check, plot holes, check continuity
+
+  cover-designer
+    Generate a complete book cover set (ebook, print, audiobook, social) with a rich visual brief
+    Keywords: design my cover, make a book cover, generate book cover, cover for my book, create cover art, cover set, book cover variants, audiobook cover, kindle cover
+
+  dialogue
+    Craft authentic dialogue with distinct character voices and subtext
+    Keywords: dialogue, conversation, character voice, how would they say, make them talk
+
+  format
+    Export manuscripts to DOCX, EPUB, PDF, KDP-ready formatting
+    Keywords: format, export, epub, kindle, KDP, pdf, docx, manuscript format
+
+  ingest-tool
+    Read source code of any tool and generate an AuthorAgent skill from it
+    Keywords: ingest tool, create skill from, import tool, make a skill, convert to skill, read this code, analyze this tool
+
+  manuscript-hub
+    Track word count, chapters, progress, streaks, and project status
+    Keywords: word count, progress, manuscript status, how's my book, writing streak, new project, start a new
+
+  nonfiction-research
+    Academic source gathering, citation management, fact-checking for nonfiction
+    Keywords: nonfiction, citation, cite, bibliography, source, academic, fact check, reference
+
+  outline
+    Create structured outlines using popular frameworks (Save the Cat, 3-Act, Hero's Journey, custom)
+    Keywords: outline, structure, plot, beats, save the cat, hero's journey, three act, story structure
+
+  premise
+    Develop compelling story premises with market awareness and emotional hooks
+    Keywords: premise, story idea, book concept, what if, high concept, elevator pitch
+
+  research
+    Constrained internet research with source tracking for fiction and nonfiction projects
+    Keywords: research, look up, find out about, fact check, what is, source
+
+  revise
+    Multi-pass revision - developmental editing, line editing, copy editing
+    Keywords: revise, edit, improve, rewrite, feedback, critique, review, developmental edit, line edit, copy edit
+
+  style-clone
+    Analyze and match the author's unique writing voice
+    Keywords: learn my style, match my voice, style check, voice profile, analyze my writing, sound like me
+
+  write
+    Draft scenes, chapters, and passages matching the author's voice and style
+    Keywords: write, draft, write a scene, write chapter, continue writing, write the
+
+── Marketing Skills (4) ──
+
+  ad-copy
+    Write ad copy for Amazon AMS, BookBub, Facebook, and other book advertising platforms
+    Keywords: ad copy, amazon ad, bookbub, facebook ad, advertising
+
+  blurb-writer
+    Write compelling book blurbs and descriptions for Amazon, Goodreads, and back cover
+    Keywords: blurb, book description, back cover, amazon description
+
+  marketing-research
+    Research literary agents, podcasts, book bloggers, reviewers, and newsletters in your genre with verified citations
+    Keywords: find literary agents, find a literary agent, find an agent for, research agents, find podcasts for authors, find author podcasts, book podcast research, find book bloggers, find book reviewers, find newsletters, find book reviewers, booktok research, bookstagram research, find indie reviewers, marketing research, promo research, find promo opportunities
+
+  website-publisher
+    Manage your author website — auto-publish books on completion, draft blog posts from your projects, render and deploy with one command
+    Keywords: publish my site, publish my website, update my website, update my site, deploy my website, deploy my site, render my site, render my website, draft a blog post, write a blog post, blog post about, announce my new book, new release post, behind the scenes post, excerpt post, teaser post, link site to project, register my site, set up my website
+
+── Ops Skills (4) ──
+
+  browser-automation
+    Drive a browser through Wave 3 author actions (KDP, AMS, BookBub, ESP) safely via a confirmation-gated executor
+    Keywords: open kdp, open amazon kdp, go to ams, submit to bookbub, browser action, automate browser, drive browser, take a screenshot, inspect page, browser doctor
+
+  decision-maker
+    Structured decision-making framework — weigh options, evaluate trade-offs, deliver clear recommendations
+    Keywords: decide, decision, pros and cons, compare options, should I, which option, trade-offs, weigh options
+
+  orchestrator-mgmt
+    Manage user scripts and automated processes — start, stop, restart, monitor, view logs
+    Keywords: script, scripts, restart script, start script, stop script, process, logs, orchestrator
+
+  task-planner
+    Break complex tasks into actionable steps with dependencies and priorities
+    Keywords: plan, break down, roadmap, step by step, how do I, task list, action plan, break this into steps
 


### PR DESCRIPTION
## Summary
- ALP-1639: replace real timers with fake timers in `step-executor-conductor.test.ts` / `router.test.ts` / `workspace-routing.test.ts` to eliminate timing-based flakiness, plus per-test timeouts for I/O-bound cases.
- ALP-1660 (regression from the ALP-1639 rewrite): the two gate-blocking tests (`a gated step opens its review gate...`, `halts cleanly at a gate...`) never called `vi.useFakeTimers()`, so `makeHandler()`'s `vi.advanceTimersByTimeAsync()` threw and the step executor recorded the gate step as `failed` instead of `awaiting_review`. Wrapped both in `vi.useFakeTimers()` / `finally { vi.useRealTimers() }` like every sibling test.
- Also fixed a `tsc --noEmit` error in `router.test.ts` (a `mock.calls` destructure had an explicit 2-tuple type annotation that didn't match `fakeSpawn`'s real 3-arg signature) that was blocking `npm run check` from going green even after the gate-test fix.

## Test plan
- [x] `npx vitest run gateway/src/services/step-executor-conductor.test.ts -t "gated step|halts cleanly at a gate"` — both pass
- [x] `npm run check` (tsc + full vitest suite) — green: 31 test files, 565 tests, 0 failures
- Verified in an isolated worktree (`AuthorAgent-alp-1639-fix`), independent of the primary shared workspace

Note: GitHub Actions CI is currently offline account-wide (billing lock) — this PR is verified via local `npm run check`, the interim discipline-based gate, not CI checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)